### PR TITLE
Add a `webrender` window system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -510,6 +510,10 @@ otherwise for the first of 'inotify', 'kqueue' or 'gfile' that is usable.])
 OPTION_DEFAULT_OFF([xwidgets],
   [enable use of xwidgets in Emacs buffers (requires gtk3 or macOS Cocoa)])
 
+OPTION_DEFAULT_OFF([webrender],
+  [enable use of webrender(written in Rust) as GUI backend on
+multiple platforms(Linux, Windows and MacOS) (experimental)])
+
 ## For the times when you want to build Emacs but don't have
 ## a suitable makeinfo, and can live without the manuals.
 dnl https://lists.gnu.org/r/emacs-devel/2008-04/msg01844.html
@@ -2207,6 +2211,11 @@ if test "${HAVE_W32}" = "yes"; then
   with_xft=no
 fi
 
+
+if test "${with_webrender}" = "yes"; then
+  window_system=webrender
+fi
+
 ## $window_system is now set to the window system we will
 ## ultimately use.
 
@@ -2245,6 +2254,9 @@ dnl use the toolkit if we have gtk, or X11R5 or newer.
   ;;
   w32 )
     term_header=w32term.h
+  ;;
+  webrender )
+    term_header=wrterm.h
   ;;
 esac
 
@@ -5416,9 +5428,16 @@ if test "${HAVE_HARFBUZZ}" = "yes" ; then
   FONT_OBJ="$FONT_OBJ hbfont.o"
 fi
 AC_SUBST(FONT_OBJ)
+
+if test "${window_system}" = "webrender" ; then
+  AC_DEFINE(USE_WEBRENDER, 1,
+	    [Define to 1 if you want to use the webrender.])
+fi
+
 AC_SUBST(XMENU_OBJ)
 AC_SUBST(XOBJ)
 AC_SUBST(FONT_OBJ)
+
 
 WIDGET_OBJ=
 MOTIF_LIBW=
@@ -5929,6 +5948,7 @@ AS_ECHO(["  Does Emacs use -lXaw3d?                                 ${HAVE_XAW3D
   Does Emacs support legacy unexec dumping?               ${with_unexec}
   Which dumping strategy does Emacs use?                  ${with_dumping}
   Does Emacs have native lisp compiler?                   ${HAVE_NATIVE_COMP}
+  Does Emacs use webrender?                               ${with_webrender}
 "])
 
 if test -n "${EMACSDATA}"; then
@@ -6060,6 +6080,9 @@ case "$window_system" in
     ;;
     w32)
         CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"window-system-w32\", "
+    ;;
+    webrender)
+        CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"window-system-webrender\", "
     ;;
 esac
 if test "$HAVE_LIBVTERM" = "yes"; then

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -78,6 +78,8 @@ window-system-nextstep = []
 window-system-w32 = []
 # Build with libvterm support.
 libvterm = []
+# Use the webrender window system
+window-system-webrender = []
 # Treat warnings as a build error on Travis.
 strict = []
 

--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -369,11 +369,12 @@ fn env_var(name: &str) -> String {
 }
 
 // What to ignore when walking the list of files
-fn ignore(path: &str, _additional_ignored_paths: &Vec<&str>) -> bool {
+fn ignore(path: &str, additional_ignored_paths: &Vec<&str>) -> bool {
     path == ""
         || path.starts_with('.')
         || path == "lib.rs"
         || path == "functions.rs"
+        || additional_ignored_paths.contains(&path)
         || if cfg!(feature = "libvterm") {
             false
         } else {
@@ -388,6 +389,9 @@ fn build_ignored_paths() -> Vec<&'static str> {
 
     #[cfg(not(feature = "window-system-x11"))]
     ignored_paths.push("xsettings.rs");
+
+    #[cfg(not(feature = "window-system-webrender"))]
+    ignored_paths.push("wrterm.rs");
 
     ignored_paths
 }

--- a/rust_src/src/eval_macros.rs
+++ b/rust_src/src/eval_macros.rs
@@ -40,3 +40,10 @@ macro_rules! list {
     ($arg:expr) => { $crate::lisp::LispObject::cons($arg, list!()) };
     () => { crate::remacs_sys::Qnil };
 }
+
+/// Macro that expands to nothing, but is used at build time to
+/// generate the starting symbol table. Equivalent to the DEFSYM
+/// macro. See also lib-src/make-docfile.c
+macro_rules! def_lisp_sym {
+    ($name:expr, $value:expr) => {};
+}

--- a/rust_src/src/frame.rs
+++ b/rust_src/src/frame.rs
@@ -1,0 +1,8 @@
+//! Generic frame functions.
+
+use crate::{lisp::ExternalPtr, remacs_sys::Lisp_Frame};
+
+/// LispFrameRef is a reference to the LispFrame
+/// However a reference is guaranteed to point to an existing frame
+/// therefore no NULL checks are needed while using it
+pub type LispFrameRef = ExternalPtr<Lisp_Frame>;

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -43,8 +43,10 @@ mod lists;
 mod multibyte;
 mod process;
 mod vectors;
+#[cfg(feature = "window-system-webrender")]
 mod wrterm;
 
+#[cfg(feature = "window-system-webrender")]
 pub use crate::wrterm::{tip_frame, wr_display_list};
 
 #[cfg(not(test))]

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -38,10 +38,14 @@ mod eval_macros;
 mod ng_async;
 
 mod eval;
+mod frame;
 mod lists;
 mod multibyte;
 mod process;
 mod vectors;
+mod wrterm;
+
+pub use crate::wrterm::{tip_frame, wr_display_list};
 
 #[cfg(not(test))]
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));

--- a/rust_src/src/wrterm.rs
+++ b/rust_src/src/wrterm.rs
@@ -1,0 +1,172 @@
+//! wrterm.rs
+
+use std::ptr;
+
+use remacs_macros::lisp_fn;
+
+use crate::{
+    frame::LispFrameRef,
+    lisp::{ExternalPtr, LispObject},
+    remacs_sys::{
+        font, image, wr_display_info, wr_output, Display, Emacs_Pixmap, Pixmap, Qnil, WRImage,
+        Window, XrmDatabase,
+    },
+};
+
+#[repr(transparent)]
+pub struct DisplayInfoRef(*mut wr_display_info);
+unsafe impl Sync for DisplayInfoRef {}
+
+pub type OutputRef = ExternalPtr<wr_output>;
+pub type DisplayRef = ExternalPtr<Display>;
+pub type ImageRef = ExternalPtr<WRImage>;
+
+#[no_mangle]
+pub static tip_frame: LispObject = Qnil;
+
+#[no_mangle]
+pub static wr_display_list: DisplayInfoRef = DisplayInfoRef(ptr::null_mut());
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_fontset(output: OutputRef) -> i32 {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_font(output: OutputRef) -> *const font {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_window_desc(output: OutputRef) -> Window {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_display_info(output: OutputRef) -> DisplayInfoRef {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_display(display_info: DisplayInfoRef) -> DisplayRef {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_baseline_offset(output: OutputRef) -> i32 {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_get_pixel(ximg: ImageRef, x: i32, y: i32) -> i32 {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn wr_free_pixmap(display: DisplayRef, pixmap: Pixmap) -> i32 {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn get_keysym_name(keysym: i32) -> *mut libc::c_char {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_clear_under_internal_border(frame: LispFrameRef) {}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_implicitly_set_name(frame: LispFrameRef, arg: LispObject, oldval: LispObject) {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_set_scroll_bar_default_width(frame: LispFrameRef) {
+    // Currently, the web render based GUI does't support scroll bar.
+    // So Do nothing.
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_set_scroll_bar_default_height(frame: LispFrameRef) {
+    // Currently, the web render based GUI does't support scroll bar.
+    // So Do nothing.
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_get_string_resource(
+    rdb: XrmDatabase,
+    name: *const libc::c_char,
+    class: *const libc::c_char,
+) -> *mut libc::c_char {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn check_x_display_info(obj: LispObject) -> DisplayInfoRef {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_bitmap_icon(frame: LispFrameRef, icon: LispObject) -> bool {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_focus_frame(frame: LispFrameRef, noactivate: bool) {
+    unimplemented!();
+}
+
+#[allow(unused_variables)]
+#[no_mangle]
+pub extern "C" fn x_set_offset(frame: LispFrameRef, xoff: i32, yoff: i32, change_gravity: i32) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn image_sync_to_pixmaps(_frame: LispFrameRef, _img: *mut image) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn image_pixmap_draw_cross(
+    _frame: LispFrameRef,
+    _pixmap: Emacs_Pixmap,
+    _x: i32,
+    _y: i32,
+    _width: i32,
+    _height: u32,
+    _color: u64,
+) {
+    unimplemented!();
+}
+
+/// Hide the current tooltip window, if there is any.
+/// Value is t if tooltip was open, nil otherwise.
+#[lisp_fn]
+pub fn x_hide_tip() -> bool {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn syms_of_wrterm() {
+    def_lisp_sym!(Qwr, "wr");
+}
+
+include!(concat!(env!("OUT_DIR"), "/wrterm_exports.rs"));

--- a/rust_src/wrapper.h
+++ b/rust_src/wrapper.h
@@ -61,3 +61,6 @@
 #endif
 #include "window.h"
 #include "xgselect.h"
+#ifdef USE_WEBRENDER
+# include "wrterm.h"
+#endif

--- a/src/dispextern.h
+++ b/src/dispextern.h
@@ -134,6 +134,15 @@ typedef Emacs_Pixmap Emacs_Pix_Context;
 #define FACE_COLOR_TO_PIXEL(face_color, frame) face_color
 #endif
 
+#ifdef USE_WEBRENDER
+#include "wrgui.h"
+typedef struct wr_display_info Display_Info;
+typedef Pixmap XImagePtr;
+typedef XImagePtr XImagePtr_or_DC;
+typedef Emacs_Pixmap Emacs_Pix_Container;
+typedef Emacs_Pixmap Emacs_Pix_Context;
+#endif
+
 #ifdef HAVE_WINDOW_SYSTEM
 # include <time.h>
 # include "fontset.h"

--- a/src/dispextern.h
+++ b/src/dispextern.h
@@ -137,7 +137,7 @@ typedef Emacs_Pixmap Emacs_Pix_Context;
 #ifdef USE_WEBRENDER
 #include "wrgui.h"
 typedef struct wr_display_info Display_Info;
-typedef Pixmap XImagePtr;
+typedef WRImage *XImagePtr;
 typedef XImagePtr XImagePtr_or_DC;
 typedef Emacs_Pixmap Emacs_Pix_Container;
 typedef Emacs_Pixmap Emacs_Pix_Context;

--- a/src/emacs.c
+++ b/src/emacs.c
@@ -1950,6 +1950,10 @@ Using an Emacs configured with --with-x-toolkit=lucid does not have this problem
       syms_of_fontset ();
 #endif /* HAVE_NS */
 
+#ifdef USE_WEBRENDER
+      syms_of_wrterm ();
+#endif /* USE_WEBRENDER */
+
       syms_of_gnutls ();
 
 #ifdef HAVE_INOTIFY

--- a/src/frame.h
+++ b/src/frame.h
@@ -574,6 +574,7 @@ struct frame
     struct x_output *x;         /* From xterm.h.  */
     struct w32_output *w32;     /* From w32term.h.  */
     struct ns_output *ns;       /* From nsterm.h.  */
+    struct wr_output *wr;       /* From wrsterm.h.  */
   }
   output_data;
 
@@ -1210,7 +1211,7 @@ default_pixels_per_inch_y (void)
 #define SET_FRAME_HEIGHT(f, height)					\
   ((f)->text_height = (height),						\
    (f)->pixel_height = ((height)					\
-    			+ FRAME_TOP_MARGIN_HEIGHT (f)			\
+                        + FRAME_TOP_MARGIN_HEIGHT (f)			\
 			+ FRAME_SCROLL_BAR_AREA_HEIGHT (f)		\
 			+ 2 * FRAME_INTERNAL_BORDER_WIDTH (f)))
 

--- a/src/image.c
+++ b/src/image.c
@@ -129,6 +129,18 @@ typedef struct ns_bitmap_record Bitmap_Record;
 
 #endif /* HAVE_NS */
 
+#ifdef USE_WEBRENDER
+typedef struct wr_bitmap_record Bitmap_Record;
+
+#define GET_PIXEL(ximg, x, y) XGetPixel (ximg, x, y)
+#define NO_PIXMAP 0
+
+#define PIX_MASK_RETAIN	0
+#define PIX_MASK_DRAW	1
+
+#endif /* WITH_WEBRENDER */
+
+
 #if (defined HAVE_X_WINDOWS \
      && ! (defined HAVE_NTGUI || defined USE_CAIRO || defined HAVE_NS))
 /* W32_TODO : Color tables on W32.  */

--- a/src/image.c
+++ b/src/image.c
@@ -132,7 +132,7 @@ typedef struct ns_bitmap_record Bitmap_Record;
 #ifdef USE_WEBRENDER
 typedef struct wr_bitmap_record Bitmap_Record;
 
-#define GET_PIXEL(ximg, x, y) XGetPixel (ximg, x, y)
+#define GET_PIXEL(ximg, x, y) wr_get_pixel(ximg, x, y)
 #define NO_PIXMAP 0
 
 #define PIX_MASK_RETAIN	0

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -4702,6 +4702,10 @@ extern void init_xterm (void);
 extern void syms_of_xterm (void);
 #endif /* HAVE_X_WINDOWS */
 
+#ifdef USE_WEBRENDER
+extern void syms_of_wrterm(void);
+#endif /* USE_WEBRENDER */
+
 #ifdef HAVE_WINDOW_SYSTEM
 /* Defined in xterm.c, nsterm.m, w32term.c.  */
 extern char *get_keysym_name (int);

--- a/src/termhooks.h
+++ b/src/termhooks.h
@@ -518,7 +518,7 @@ struct terminal
      BGCOLOR.  */
   void (*query_frame_background_color) (struct frame *f, Emacs_Color *bgcolor);
 
-#if defined (HAVE_X_WINDOWS) || defined (HAVE_NTGUI)
+#if defined (HAVE_X_WINDOWS) || defined (HAVE_NTGUI) || defined (USE_WEBRENDER)
   /* On frame F, translate pixel colors to RGB values for the NCOLORS
      colors in COLORS.  Use cached information, if available.  */
 

--- a/src/termhooks.h
+++ b/src/termhooks.h
@@ -60,7 +60,8 @@ enum output_method
   output_x_window,
   output_msdos_raw,
   output_w32,
-  output_ns
+  output_ns,
+  output_wr
 };
 
 /* Input queue declarations and hooks.  */
@@ -445,6 +446,7 @@ struct terminal
     struct x_display_info *x;         /* xterm.h */
     struct w32_display_info *w32;     /* w32term.h */
     struct ns_display_info *ns;       /* nsterm.h */
+    struct wr_display_info *wr;       /* wrterm.h */
   } display_info;
 
 
@@ -833,6 +835,9 @@ extern struct terminal *terminal_list;
 #elif defined (HAVE_NS)
 #define TERMINAL_FONT_CACHE(t)						\
   (t->type == output_ns ? t->display_info.ns->name_list_element : Qnil)
+#elif defined (USE_WEBRENDER)
+#define TERMINAL_FONT_CACHE(t)						\
+  (t->type == output_wr ? t->display_info.wr ->name_list_element : Qnil)
 #endif
 
 extern struct terminal *decode_live_terminal (Lisp_Object);

--- a/src/window.c
+++ b/src/window.c
@@ -2632,8 +2632,10 @@ candidate_window_p (Lisp_Object window, Lisp_Object owindow,
 			`visible'.  I'd argue it should be at least
 			something like `iconified', but don't know how to do
 			that yet.  --Stef  */
-		     || (FRAME_X_P (f) && f->output_data.x->asked_for_visible
-			 && !f->output_data.x->has_been_visible)
+		     || (FRAME_X_P (f) && FRAME_X_OUTPUT (f)->asked_for_visible
+		         && !FRAME_X_OUTPUT (f)->has_been_visible)
+
+
 #endif
 		     )
 	&& (FRAME_TERMINAL (XFRAME (w->frame))

--- a/src/wrgui.h
+++ b/src/wrgui.h
@@ -48,12 +48,12 @@ typedef void *Emacs_Pixmap;
 #define XChar2b wchar_t
 
 /* Windows equivalent of XImage.  */
-typedef struct _XImage
+typedef struct _WRImage
 {
   unsigned char *data;
   int info;
   /* Optional RGBQUAD array for palette follows (see BITMAPINFO docs).  */
-} XImage;
+} WRImage;
 
 typedef struct
 {
@@ -80,6 +80,15 @@ typedef struct
    (nr).y = (y_v),				\
    (nr).width = (width_v),	\
    (nr).height = (height_v))
+
+#define STORE_XCHAR2B(chp, b1, b2) \
+  (*(chp) = ((XChar2b)((((b1) & 0x00ff) << 8) | ((b2) & 0x00ff))))
+
+#define XCHAR2B_BYTE1(chp) \
+  ((*(chp) & 0xff00) >> 8)
+
+#define XCHAR2B_BYTE2(chp) \
+  (*(chp) & 0x00ff)
 
 /* Bit Gravity */
 

--- a/src/wrgui.h
+++ b/src/wrgui.h
@@ -1,0 +1,119 @@
+/* Definitions and headers for webrender GUI backend.
+   Copyright (C) 1995, 2001-2017 Free Software Foundation, Inc.
+
+This file is part of GNU Emacs.
+
+GNU Emacs is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at
+your option) any later version.
+
+GNU Emacs is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#ifndef EMACS_WRGUI_H
+#define EMACS_WRGUI_H
+
+/* Emulate X GC's by keeping color and font info in a structure.  */
+typedef struct _XGCValues
+{
+  unsigned long foreground;
+  unsigned long background;
+  struct font *font;
+} XGCValues;
+
+#define GCForeground 0x01
+#define GCBackground 0x02
+#define GCFont 0x03
+#define GCGraphicsExposures 0
+
+typedef void *Pixmap;
+
+typedef char *XrmDatabase;
+
+typedef XGCValues *GC;
+typedef int Color;
+typedef int Window;
+typedef int Display; /* HDC so it doesn't conflict with xpm lib.  */
+typedef void *Emacs_Cursor;
+typedef int RGB_PIXEL_COLOR;
+
+typedef void *Emacs_Pixmap;
+
+#define XChar2b wchar_t
+
+/* Windows equivalent of XImage.  */
+typedef struct _XImage
+{
+  unsigned char *data;
+  int info;
+  /* Optional RGBQUAD array for palette follows (see BITMAPINFO docs).  */
+} XImage;
+
+typedef struct
+{
+  int x, y;
+  unsigned width, height;
+} XRectangle;
+
+#define NativeRectangle Emacs_Rectangle
+
+#define CONVERT_TO_EMACS_RECT(xr,nr)            \
+  ((xr).x = (nr).x,				\
+   (xr).y = (nr).y,				\
+   (xr).width = (nr).width,	\
+   (xr).height = (nr).height)
+
+#define CONVERT_FROM_EMACS_RECT(xr,nr)		\
+  ((nr).x = (xr).x,				\
+   (nr).y = (xr).y,				\
+   (nr).width = (xr).width,	\
+   (nr).height = (xr).height)
+
+#define STORE_NATIVE_RECT(nr,x_v,y_v,width_v,height_v)	\
+  ((nr).x = (x_v),				\
+   (nr).y = (y_v),				\
+   (nr).width = (width_v),	\
+   (nr).height = (height_v))
+
+/* Bit Gravity */
+
+#define ForgetGravity 0
+#define NorthWestGravity 1
+#define NorthGravity 2
+#define NorthEastGravity 3
+#define WestGravity 4
+#define CenterGravity 5
+#define EastGravity 6
+#define SouthWestGravity 7
+#define SouthGravity 8
+#define SouthEastGravity 9
+#define StaticGravity 10
+
+#define NoValue 0x0000
+#define XValue 0x0001
+#define YValue 0x0002
+#define WidthValue 0x0004
+#define HeightValue 0x0008
+#define AllValues 0x000F
+#define XNegative 0x0010
+#define YNegative 0x0020
+
+#define USPosition (1L << 0) /* user specified x, y */
+#define USSize (1L << 1) /* user specified width, height */
+
+#define PPosition (1L << 2) /* program specified position */
+#define PSize (1L << 3) /* program specified size */
+#define PMinSize (1L << 4) /* program specified minimum size */
+#define PMaxSize (1L << 5) /* program specified maximum size */
+#define PResizeInc (1L << 6) /* program specified resize increments */
+#define PAspect (1L << 7) /* program specified min and max aspect ratios */
+#define PBaseSize (1L << 8) /* program specified base for incrementing */
+#define PWinGravity (1L << 9) /* program specified window gravity */
+
+#endif /* EMACS_WRGUI_H */

--- a/src/wrterm.h
+++ b/src/wrterm.h
@@ -26,9 +26,6 @@ struct wr_display_info
   /* Dots per inch of the screen.  */
   double resx, resy;
 
-  /* The Screen this connection is connected to.  */
-  Screen *screen;
-
   /* Number of planes on this screen.  */
   int n_planes;
 
@@ -85,9 +82,6 @@ struct wr_display_info
      This is a position on last_mouse_motion_frame.  */
   int last_mouse_motion_x;
   int last_mouse_motion_y;
-
-  /* This says how to access this display in Xlib.  */
-  Display *display;
 };
 
 extern struct wr_display_info *x_display_list;
@@ -121,18 +115,23 @@ struct wr_output
   /* This is the Emacs structure for the X display this frame is on.  */
   struct wr_display_info *display_info;
 
-  /* Default ASCII font of this frame.  */
-  struct font *font;
-
 };
 
+typedef struct wr_output wr_output;
+typedef struct wr_display_info wr_display_info;
 
+extern Window wr_get_window_desc(wr_output* output);
+extern int wr_get_fontset(wr_output* output);
+extern struct font *wr_get_font(wr_output* output);
+extern wr_display_info *wr_get_display_info(wr_output* output);
+extern Display *wr_get_display(wr_display_info* output);
+extern Screen wr_get_screen(wr_display_info* output);
 
 /* This is the `Display *' which frame F is on.  */
-#define FRAME_X_DISPLAY(f) (FRAME_DISPLAY_INFO (f)->display)
+#define FRAME_X_DISPLAY(f) (wr_get_display(FRAME_DISPLAY_INFO (f)))
 
 /* This gives the x_display_info structure for the display F is on.  */
-#define FRAME_DISPLAY_INFO(f) (FRAME_X_OUTPUT (f)->display_info)
+#define FRAME_DISPLAY_INFO(f) (wr_get_display_info(FRAME_X_OUTPUT (f)))
 
 /* Return the X output data for frame F.  */
 #define FRAME_X_OUTPUT(f) ((f)->output_data.wr)
@@ -140,8 +139,17 @@ struct wr_output
 #define FRAME_OUTPUT_DATA(f) FRAME_X_OUTPUT (f)
 
 /* This is the `Screen *' which frame F is on.  */
-#define FRAME_X_SCREEN(f) (FRAME_DISPLAY_INFO (f)->screen)
+#define FRAME_X_SCREEN(f) (wr_get_display_info(FRAME_X_OUTPUT (f)))
+
+/* Return the X window used for displaying data in frame F.  */
+#define FRAME_X_WINDOW(f)  (wr_get_window_desc(FRAME_X_OUTPUT (f)))
+#define FRAME_NATIVE_WINDOW(f) FRAME_X_WINDOW (f)
+
+#define FRAME_FONTSET(f) (wr_get_fontset(FRAME_X_OUTPUT (f)))
+#define FRAME_FONT(f) (wr_get_font(FRAME_X_OUTPUT (f)))
 
 
+#define BLACK_PIX_DEFAULT(f) 0
+#define WHITE_PIX_DEFAULT(f) 65535
 
 #endif // __WRTERM_H_

--- a/src/wrterm.h
+++ b/src/wrterm.h
@@ -1,0 +1,147 @@
+#ifndef __WRTERM_H_
+#define __WRTERM_H_
+
+#include "dispextern.h"
+
+struct wr_bitmap_record
+{
+  char *file;
+  int refcount;
+  int height, width, depth;
+};
+
+typedef int Screen;
+
+struct wr_display_info
+{
+  /* Chain of all wr_display_info structures.  */
+  struct wr_display_info *next;
+
+  /* The generic display parameters corresponding to this NS display.  */
+  struct terminal *terminal;
+
+  /* This is a cons cell of the form (NAME . FONT-LIST-CACHE).  */
+  Lisp_Object name_list_element;
+
+  /* Dots per inch of the screen.  */
+  double resx, resy;
+
+  /* The Screen this connection is connected to.  */
+  Screen *screen;
+
+  /* Number of planes on this screen.  */
+  int n_planes;
+
+  /* Mask of things that cause the mouse to be grabbed.  */
+  int grabbed;
+
+  /* The root window of this screen.  */
+  Window root_window;
+
+  /* The cursor to use for vertical scroll bars.  */
+  Emacs_Cursor vertical_scroll_bar_cursor;
+
+  /* Resource data base */
+  XrmDatabase rdb;
+
+  /* Minimum width over all characters in all fonts in font_table.  */
+  int smallest_char_width;
+
+  /* Minimum font height over all fonts in font_table.  */
+  int smallest_font_height;
+
+  /* Information about the range of text currently shown in
+     mouse-face.  */
+  Mouse_HLInfo mouse_highlight;
+
+  /* The number of fonts actually stored in wr_font_table.
+     font_table[n] is used and valid if 0 <= n < n_fonts. 0 <=
+     n_fonts <= font_table_size. and font_table[i].name != 0. */
+  int n_fonts;
+
+  /* Pointer to bitmap records.  */
+  struct wr_bitmap_record *bitmaps;
+
+  /* Allocated size of bitmaps field.  */
+  ptrdiff_t bitmaps_size;
+
+  /* Last used bitmap index.  */
+  ptrdiff_t bitmaps_last;
+
+
+  /* The frame which currently has the visual highlight, and should get
+     keyboard input (other sorts of input have the frame encoded in the
+     event).  It points to the focus frame's selected window's
+     frame. */
+  struct frame *highlight_frame;
+
+  /* The frame where the mouse was last time we reported a mouse event.  */
+  struct frame *last_mouse_frame;
+
+  /* The frame where the mouse was last time we reported a mouse motion.  */
+  struct frame *last_mouse_motion_frame;
+
+  /* Position where the mouse was last time we reported a motion.
+     This is a position on last_mouse_motion_frame.  */
+  int last_mouse_motion_x;
+  int last_mouse_motion_y;
+
+  /* This says how to access this display in Xlib.  */
+  Display *display;
+};
+
+extern struct wr_display_info *x_display_list;
+
+struct wr_output
+{
+
+  /* The X window that is the parent of this X window.
+     Usually this is a window that was made by the window manager,
+     but it can be the root window, and it can be explicitly specified
+     (see the explicit_parent field, below).  */
+  Window parent_desc;
+
+  /* Descriptor for the cursor in use for this window.  */
+  Emacs_Cursor text_cursor;
+  Emacs_Cursor nontext_cursor;
+  Emacs_Cursor modeline_cursor;
+  Emacs_Cursor hand_cursor;
+  Emacs_Cursor hourglass_cursor;
+  Emacs_Cursor horizontal_drag_cursor;
+  Emacs_Cursor vertical_drag_cursor;
+  Emacs_Cursor left_edge_cursor;
+  Emacs_Cursor top_left_corner_cursor;
+  Emacs_Cursor top_edge_cursor;
+  Emacs_Cursor top_right_corner_cursor;
+  Emacs_Cursor right_edge_cursor;
+  Emacs_Cursor bottom_right_corner_cursor;
+  Emacs_Cursor bottom_edge_cursor;
+  Emacs_Cursor bottom_left_corner_cursor;
+
+  /* This is the Emacs structure for the X display this frame is on.  */
+  struct wr_display_info *display_info;
+
+  /* Default ASCII font of this frame.  */
+  struct font *font;
+
+};
+
+
+
+/* This is the `Display *' which frame F is on.  */
+#define FRAME_X_DISPLAY(f) (FRAME_DISPLAY_INFO (f)->display)
+
+/* This gives the x_display_info structure for the display F is on.  */
+#define FRAME_DISPLAY_INFO(f) (FRAME_X_OUTPUT (f)->display_info)
+
+/* Return the X output data for frame F.  */
+#define FRAME_X_OUTPUT(f) ((f)->output_data.wr)
+
+#define FRAME_OUTPUT_DATA(f) FRAME_X_OUTPUT (f)
+
+/* This is the `Screen *' which frame F is on.  */
+#define FRAME_X_SCREEN(f) (FRAME_DISPLAY_INFO (f)->screen)
+
+
+
+#endif // __WRTERM_H_

--- a/src/wrterm.h
+++ b/src/wrterm.h
@@ -84,7 +84,8 @@ struct wr_display_info
   int last_mouse_motion_y;
 };
 
-extern struct wr_display_info *x_display_list;
+extern struct wr_display_info *wr_display_list;
+#define x_display_list wr_display_list
 
 struct wr_output
 {
@@ -126,6 +127,8 @@ extern struct font *wr_get_font(wr_output* output);
 extern wr_display_info *wr_get_display_info(wr_output* output);
 extern Display *wr_get_display(wr_display_info* output);
 extern Screen wr_get_screen(wr_display_info* output);
+extern int wr_get_baseline_offset(wr_output* output);
+extern int wr_get_pixel(WRImage *ximg, int x, int y);
 
 /* This is the `Display *' which frame F is on.  */
 #define FRAME_X_DISPLAY(f) (wr_get_display(FRAME_DISPLAY_INFO (f)))
@@ -137,6 +140,8 @@ extern Screen wr_get_screen(wr_display_info* output);
 #define FRAME_X_OUTPUT(f) ((f)->output_data.wr)
 
 #define FRAME_OUTPUT_DATA(f) FRAME_X_OUTPUT (f)
+
+#define FRAME_BASELINE_OFFSET(f) (wr_get_baseline_offset(FRAME_X_OUTPUT (f)))
 
 /* This is the `Screen *' which frame F is on.  */
 #define FRAME_X_SCREEN(f) (wr_get_display_info(FRAME_X_OUTPUT (f)))

--- a/src/xfaces.c
+++ b/src/xfaces.c
@@ -571,6 +571,26 @@ x_free_gc (struct frame *f, Emacs_GC *gc)
 }
 #endif  /* HAVE_NS */
 
+#ifdef USE_WEBRENDER
+/* webrender emulation of GCs */
+
+static GC
+x_create_gc (struct frame *f,
+	     unsigned long mask,
+	     XGCValues *xgcv)
+{
+  GC gc = malloc (sizeof *gc);
+  *gc = *xgcv;
+  return gc;
+}
+
+static void
+x_free_gc (struct frame *f, GC gc)
+{
+  free (gc);
+}
+#endif  /* USE_WEBRENDER */
+
 /***********************************************************************
 			   Frames and faces
  ***********************************************************************/


### PR DESCRIPTION
* Add new option `--with-webrender` in `configuration.ac` 
* Add new cargo feature `windows-system-webrender` in rust_src

It's buildable while the result binary isn't runnable.