### PR TITLE
JS Performance Improvements

### DIFF
--- a/test/js/basicLisp.js
+++ b/test/js/basicLisp.js
@@ -16,18 +16,20 @@ export function basicLisp() {
 	})
 	.test(() => {
 	    let mutated = 0;
-	    let myFunc = lisp.defun("hello", (arg) => {
+	    let myFunc = lisp.defun("hello", (arg, arg2) => {
+		console.log("First Value " + arg + ", " + arg2);
 		mutated = arg;
+		return 4;
 	    });
-	    lisp.hello(1);
+	    lisp.hello(1, 3);
 
-	    let myFuncTwo = lisp.defun("helloTwo", "myDocString", (arg) => { });
+	    let myFuncTwo = lisp.defun("helloTwo", "myDocString", (arg) => { return arg; });
 	    lisp.helloTwo(2);
 
 	    let myFuncThree = lisp.defun("helloThree", {interactive: true, arg: "P\nbbuffer:"}, (arg) => { });
 	    lisp.helloThree(3);
 
-	    let myFuncFour = lisp.defun("helloFour", "HelloFour", {interactive: true}, () => { });
+	    let myFuncFour = lisp.defun("helloFour", "HelloFour", {interactive: true}, () => { console.log('no args'); });
 	    lisp.helloFour();
 
 	    let myFuncFive = lisp.defun({
@@ -38,6 +40,7 @@ export function basicLisp() {
 		func: (a) => { return (a); }
 	    });
 
+	    console.log(lisp.helloFive(1));
 	    if (lisp.helloFive(1) !== 1) {
 		throw new Error("Return Value incorrect for Defun");
 	    }

--- a/test/js/basicLisp.js
+++ b/test/js/basicLisp.js
@@ -17,7 +17,6 @@ export function basicLisp() {
 	.test(() => {
 	    let mutated = 0;
 	    let myFunc = lisp.defun("hello", (arg, arg2) => {
-		console.log("First Value " + arg + ", " + arg2);
 		mutated = arg;
 		return 4;
 	    });
@@ -29,7 +28,7 @@ export function basicLisp() {
 	    let myFuncThree = lisp.defun("helloThree", {interactive: true, arg: "P\nbbuffer:"}, (arg) => { });
 	    lisp.helloThree(3);
 
-	    let myFuncFour = lisp.defun("helloFour", "HelloFour", {interactive: true}, () => { console.log('no args'); });
+	    let myFuncFour = lisp.defun("helloFour", "HelloFour", {interactive: true}, () => { });
 	    lisp.helloFour();
 
 	    let myFuncFive = lisp.defun({
@@ -40,7 +39,6 @@ export function basicLisp() {
 		func: (a) => { return (a); }
 	    });
 
-	    console.log(lisp.helloFive(1));
 	    if (lisp.helloFive(1) !== 1) {
 		throw new Error("Return Value incorrect for Defun");
 	    }


### PR DESCRIPTION
Results: Measurable improvement for JS -> Lisp Performance in multiple cases. 
All tests are based on 10,000 iterations 
| Test              | Pre-PR        | Post-PR  | % Improvement
| ------------- |:-------------:| ---------:| ------:|
| T1                | 775ms         |   356ms  |  54% |
| T2                | 45ms           |   8ms      | 82%  |
| T3                | 70ms           |   27ms    | 61%  |
| T4                | 32ms           |   22ms    | 31%  |

T1: (with-temp-buffer (insert "foo")) and JS equivalent
T2: (conat "foo" "bar") and JS equivalent 
T3: (intern "foo") and JS equivalent
T4: (insert "Hello World") and JS equivalent 

Lessons Learned:
* Using WeakRef caches is a powerful tool in the cases of tight loops calling lisp functions with similar arguments. Previously, when calling `lisp.insert("Hello")`, we would allocate a lisp string for every allocation, despite the fact that string does not change. Now we have a cached value that will only allocate once. 
* The bare minimum cost of a bridge cross between JS -> C/Rust is very small compared to the cost of allocating lisp or v8 JS objects. 
* `make_proxy!` was very slow, due to the fact we were creating an object template every time. We now have a global value that we save between calls. 
* Creating a lisp lambda from a JS lambda was slow. We now have a helper function to reduce the number of allocations and bridge crosses in creating lambda functions. 