### PR TITLE
Removing deno submodule for ease-of-use

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "rust_src/deno"]
-	path = rust_src/deno
-	url = https://github.com/DavidDeSimone/deno

--- a/README.md
+++ b/README.md
@@ -78,24 +78,14 @@ emacs-ng's JS implementation clocks in over **50 times** faster than emacs 28 wi
    IMPORTANT: Whenever the toolchain updates, you have to reinstall
    rustfmt manually.
    
-   
-2. You will need to clone the repository. emacs-ng uses submodules,
-   so you can either run
-   
-        git clone --recurse-submodules https://github.com/emacs-ng/emacs-ng
-	
-   or you can clone as normal and run
-       
-        git submodule init && git submodule update 
-
-3. You will need a C compiler and toolchain. On Linux, you can do
+2. You will need a C compiler and toolchain. On Linux, you can do
    something like:
 
         apt install build-essential automake clang libclang-dev
 
    On macOS, you'll need Xcode.
 
-4. Linux:
+3. Linux:
 
         apt install texinfo libjpeg-dev libtiff-dev \
           libgif-dev libxpm-dev libgtk-3-dev gnutls-dev \

--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72c1f1154e234325b50864a349b9c8e56939e266a4c307c0f159812df2f9537"
 dependencies = [
  "brotli",
- "bytes 0.5.6",
+ "bytes",
  "flate2",
  "futures-core",
  "memchr",
@@ -265,12 +265,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "bytesize"
@@ -585,11 +579,11 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.6.3"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
 dependencies = [
  "atty",
  "base64 0.12.3",
  "byteorder",
- "chrono",
  "clap",
  "deno_core",
  "deno_doc",
@@ -601,7 +595,6 @@ dependencies = [
  "dprint-plugin-typescript",
  "encoding_rs",
  "env_logger",
- "exec",
  "filetime",
  "fwdansi",
  "http",
@@ -613,7 +606,6 @@ dependencies = [
  "lspower",
  "nix",
  "notify",
- "os_pipe",
  "percent-encoding",
  "regex 1.4.2",
  "ring",
@@ -628,11 +620,8 @@ dependencies = [
  "swc_ecmascript",
  "tempfile",
  "termcolor",
- "test_util",
- "tokio 0.2.24",
+ "tokio",
  "tokio-rustls",
- "tokio-tungstenite",
- "tower-test",
  "uuid",
  "walkdir",
  "winapi 0.3.9",
@@ -642,6 +631,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.75.0"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
 dependencies = [
  "anyhow",
  "futures",
@@ -654,13 +644,13 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "tokio 0.3.6",
  "url",
 ]
 
 [[package]]
 name = "deno_crypto"
 version = "0.9.0"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
 dependencies = [
  "deno_core",
  "rand 0.7.3",
@@ -685,6 +675,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.18.0"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
 dependencies = [
  "deno_core",
  "reqwest",
@@ -712,6 +703,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.5.0"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
 dependencies = [
  "atty",
  "deno_core",
@@ -740,8 +732,7 @@ dependencies = [
  "shell-escape",
  "sys-info",
  "termcolor",
- "test_util",
- "tokio 0.2.24",
+ "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
  "uuid",
@@ -754,9 +745,9 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.26.0"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
 dependencies = [
  "deno_core",
- "futures",
  "idna",
  "serde",
 ]
@@ -876,7 +867,7 @@ dependencies = [
  "deno",
  "deno_core",
  "deno_runtime",
- "errno 0.2.7",
+ "errno",
  "field-offset",
  "flate2",
  "futures",
@@ -894,7 +885,7 @@ dependencies = [
  "serde_json",
  "systemstat",
  "tempfile",
- "tokio 0.2.24",
+ "tokio",
  "tokio-rustls",
 ]
 
@@ -934,17 +925,6 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
-dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "errno"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
@@ -961,16 +941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 dependencies = [
  "gcc",
- "libc",
-]
-
-[[package]]
-name = "exec"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615"
-dependencies = [
- "errno 0.2.7",
  "libc",
 ]
 
@@ -1263,7 +1233,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1271,7 +1241,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1307,7 +1277,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1318,7 +1288,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "http",
 ]
 
@@ -1349,7 +1319,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1361,7 +1331,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.2",
  "socket2",
- "tokio 0.2.24",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1373,12 +1343,12 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-util",
  "hyper",
  "log",
  "rustls",
- "tokio 0.2.24",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -1442,16 +1412,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.5.6",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if 1.0.0",
+ "bytes",
 ]
 
 [[package]]
@@ -1590,18 +1551,9 @@ name = "lisp-util"
 version = "0.1.0"
 dependencies = [
  "darling 0.2.2",
- "errno 0.2.7",
+ "errno",
  "libc",
  "syn 0.11.11",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -1647,7 +1599,7 @@ checksum = "64106b17ca8f6f73cc21a3d1f39684ff65293a291aa96026aee85eaae02339a5"
 dependencies = [
  "async-trait",
  "auto_impl",
- "bytes 0.5.6",
+ "bytes",
  "dashmap",
  "futures",
  "log",
@@ -1656,7 +1608,7 @@ dependencies = [
  "nom 5.1.2",
  "serde",
  "serde_json",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "tower-service",
 ]
@@ -1746,19 +1698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
-dependencies = [
- "libc",
- "log",
- "miow 0.3.6",
- "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,7 +1705,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
- "mio 0.6.23",
+ "mio",
  "slab",
 ]
 
@@ -1777,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
- "mio 0.6.23",
+ "mio",
  "miow 0.3.6",
  "winapi 0.3.9",
 ]
@@ -1790,7 +1729,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.23",
+ "mio",
 ]
 
 [[package]]
@@ -1881,18 +1820,9 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio 0.6.23",
+ "mio",
  "mio-extras",
  "walkdir",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1959,47 +1889,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2195,16 +2090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "pty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50f3d255966981eb4e4c5df3e983e6f7d163221f547406d83b6a460ff5c5ee8"
-dependencies = [
- "errno 0.1.8",
- "libc",
 ]
 
 [[package]]
@@ -2483,7 +2368,7 @@ name = "remacs-lib"
 version = "0.1.0"
 dependencies = [
  "darling 0.2.2",
- "errno 0.2.7",
+ "errno",
  "lazy_static",
  "libc",
  "lisp-util",
@@ -2509,7 +2394,7 @@ checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2528,7 +2413,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_urlencoded",
- "tokio 0.2.24",
+ "tokio",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
@@ -3294,23 +3179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_util"
-version = "0.1.0"
-dependencies = [
- "bytes 0.5.6",
- "futures",
- "hyper",
- "lazy_static",
- "os_pipe",
- "pty",
- "regex 1.4.2",
- "tempfile",
- "tokio 0.2.24",
- "tokio-rustls",
- "tokio-tungstenite",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3398,43 +3266,21 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.6.23",
+ "mio",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
- "tokio-macros 0.2.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
-dependencies = [
- "autocfg 1.0.1",
- "bytes 0.6.0",
- "futures-core",
- "libc",
- "memchr",
- "mio 0.7.7",
- "num_cpus",
- "once_cell",
- "parking_lot",
- "pin-project-lite 0.2.0",
- "signal-hook-registry",
- "slab",
- "tokio-macros 0.3.2",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -3450,17 +3296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.57",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,19 +3303,8 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.24",
+ "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "tokio 0.2.24",
 ]
 
 [[package]]
@@ -3492,7 +3316,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tungstenite",
 ]
 
@@ -3502,12 +3326,12 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -3520,30 +3344,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
-
-[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
-
-[[package]]
-name = "tower-test"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba4bbc2c1e4a8543c30d4c13a4c8314ed72d6e07581910f665aa13fde0153c8"
-dependencies = [
- "futures-util",
- "pin-project 0.4.27",
- "tokio 0.2.24",
- "tokio-test",
- "tower-layer",
- "tower-service",
-]
 
 [[package]]
 name = "tracing"
@@ -3590,7 +3394,7 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes 0.5.6",
+ "bytes",
  "http",
  "httparse",
  "input_buffer",

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -18,9 +18,9 @@ lisp-util = { version = "0.1.0", path = "crates/lisp_util" }
 lisp-macros = { version = "0.1.0", path = "crates/lisp_macros" }
 clippy = { version = "*", optional = true }
 cfg-if = "0.1"
-deno_core = { version = "0.75.0", path = "deno/core" }
-deno_runtime = { version = "0.5.0", path = "deno/runtime" }
-deno = { version = "1.6.3", path = "deno/cli" }
+deno_core = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng" }
+deno_runtime = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng" }
+deno = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng" }
 crossbeam = "0.8"
 errno = "0.2"
 field-offset = "0.1"


### PR DESCRIPTION
@harryfei had a good recommendation to move to using [this cargo feature](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) instead of using a git submodule. In testing this feature, it seems like nothing but upside. 