### PR TITLE
Fix Rust debug builds and '--without-x' builds.

### DIFF
--- a/rust_src/crates/lisp/src/frame.rs
+++ b/rust_src/crates/lisp/src/frame.rs
@@ -1,14 +1,14 @@
 //! Generic frame functions.
-
-use std::ffi::CString;
-
 use crate::{
     lisp::{ExternalPtr, LispObject},
-    remacs_sys::{
-        frame_dimension, gui_default_parameter, resource_types, vertical_scroll_bar_type,
-        Lisp_Frame, Lisp_Type,
-    },
+    remacs_sys::{frame_dimension, Lisp_Frame, Lisp_Type},
     vector::LispVectorlikeRef,
+};
+
+#[cfg(feature = "window-system")]
+use {
+    crate::remacs_sys::{gui_default_parameter, resource_types, vertical_scroll_bar_type},
+    std::ffi::CString,
 };
 
 /// LispFrameRef is a reference to the LispFrame
@@ -101,6 +101,7 @@ impl LispFrameRef {
             - 2 * self.internal_border_width()
     }
 
+    #[cfg(feature = "window-system")]
     pub fn gui_default_parameter(
         mut self,
         alist: LispObject,

--- a/rust_src/crates/lisp/src/lib.rs
+++ b/rust_src/crates/lisp/src/lib.rs
@@ -31,6 +31,7 @@ pub mod lisp;
 pub mod eval;
 pub mod font;
 pub mod frame;
+#[cfg(feature = "window-system")]
 pub mod glyph;
 pub mod keyboard;
 pub mod list;


### PR DESCRIPTION
Latest push on master seems to have broken --enable-rust-debug (due to a linker error that is optimized into being a non-issue in an optimized build), and --without-x (due to some assumptions about fields in C structs that are compiled out in --without-x). 

