### PR TITLE
Reduce unneeded polls to event loop

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.6.3"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#f2aa5ffd13ca5b87c41410177ba0971c3e5469be"
 dependencies = [
  "atty",
  "base64 0.12.3",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.75.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#f2aa5ffd13ca5b87c41410177ba0971c3e5469be"
 dependencies = [
  "anyhow",
  "futures",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto"
 version = "0.9.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#f2aa5ffd13ca5b87c41410177ba0971c3e5469be"
 dependencies = [
  "deno_core",
  "rand 0.7.3",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.18.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#f2aa5ffd13ca5b87c41410177ba0971c3e5469be"
 dependencies = [
  "deno_core",
  "reqwest",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.5.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#f2aa5ffd13ca5b87c41410177ba0971c3e5469be"
 dependencies = [
  "atty",
  "deno_core",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.26.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#f2aa5ffd13ca5b87c41410177ba0971c3e5469be"
 dependencies = [
  "deno_core",
  "idna",

--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.6.3"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
 dependencies = [
  "atty",
  "base64 0.12.3",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.75.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
 dependencies = [
  "anyhow",
  "futures",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto"
 version = "0.9.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
 dependencies = [
  "deno_core",
  "rand 0.7.3",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.18.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
 dependencies = [
  "deno_core",
  "reqwest",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.5.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
 dependencies = [
  "atty",
  "deno_core",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.26.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#0ee071f887a120149fd1d15528bdf5f2e1783f19"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#5debde9ff0553af405fe37dc9188c47a8464370f"
 dependencies = [
  "deno_core",
  "idna",

--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -77,6 +77,7 @@ struct EmacsMainJsRuntime {
     /// not stored in EmacsJsOptions.
     program_state: Option<Arc<deno::program_state::ProgramState>>,
     within_toplevel: bool,
+    tick_scheduled: bool,
 }
 
 impl Default for EmacsMainJsRuntime {
@@ -91,6 +92,7 @@ impl Default for EmacsMainJsRuntime {
             proxy_template: None,
             program_state: None,
             within_toplevel: false,
+	    tick_scheduled: false,
         }
     }
 }
@@ -98,7 +100,7 @@ impl Default for EmacsMainJsRuntime {
 impl Default for EmacsJsOptions {
     fn default() -> Self {
         Self {
-            tick_rate: 0.1,
+            tick_rate: 0.001,
             ops: None,
             error_handler: lisp::remacs_sys::Qnil,
             inspect: None,
@@ -286,6 +288,14 @@ impl EmacsMainJsRuntime {
                 main.options.ops = Some(deno_runtime::permissions::Permissions::allow_all())
             }
         });
+    }
+
+    fn set_tick_scheduled(b: bool) {
+	Self::access(|main| main.tick_scheduled = b);
+    }
+
+    fn get_tick_scheduled() -> bool {
+	Self::access(|main| main.tick_scheduled)
     }
 }
 
@@ -1192,7 +1202,7 @@ fn js_reenter_inner(scope: &mut v8::HandleScope, args: &[LispObject]) -> LispObj
 
 #[lisp_fn(min = "1")]
 pub fn js__reenter(args: &[LispObject]) -> LispObject {
-    inner_invokation(move |scope| js_reenter_inner(scope, args))
+    inner_invokation(move |scope| js_reenter_inner(scope, args), true)
 }
 
 fn js_clear_internal(scope: &mut v8::HandleScope, idx: LispObject) {
@@ -1216,7 +1226,7 @@ fn js_clear_internal(scope: &mut v8::HandleScope, idx: LispObject) {
     fnc.call(scope, recv, v8_args.as_slice()).unwrap();
 }
 
-fn inner_invokation<F, R: Sized>(f: F) -> R where F: Fn(&mut v8::HandleScope) -> R {
+fn inner_invokation<F, R: Sized>(f: F, should_schedule: bool) -> R where F: Fn(&mut v8::HandleScope) -> R {
     let result;
     if !EmacsMainJsRuntime::is_within_runtime() {
         let mut worker_handle = EmacsMainJsRuntime::get_deno_worker();
@@ -1228,6 +1238,15 @@ fn inner_invokation<F, R: Sized>(f: F) -> R where F: Fn(&mut v8::HandleScope) ->
         EmacsMainJsRuntime::enter_runtime();
         result = handle.block_on(async move { f(scope) });
         EmacsMainJsRuntime::exit_runtime();
+	println!("Inner Invokation...");
+	// Only in the case that the event loop as gone to sleep,
+	// we want to reinvoke it, in case the above
+	// invokation has scheduled promises.
+	if !EmacsMainJsRuntime::get_tick_scheduled()
+	    && should_schedule {
+	    println!("Scheduled...");
+	    schedule_tick();
+	}
     } else {
         let scope: &mut v8::HandleScope = unsafe { EmacsMainJsRuntime::get_stacked_v8_handle() };
         result = f(scope);
@@ -1239,7 +1258,7 @@ fn inner_invokation<F, R: Sized>(f: F) -> R where F: Fn(&mut v8::HandleScope) ->
 
 #[lisp_fn]
 pub fn js__clear(idx: LispObject) -> LispObject {
-    inner_invokation(move |scope| js_clear_internal(scope, idx));
+    inner_invokation(move |scope| js_clear_internal(scope, idx), false);
     lisp::remacs_sys::Qnil
 }
 
@@ -1290,28 +1309,33 @@ fn js_sweep_inner(scope: &mut v8::HandleScope) {
 #[lisp_fn]
 pub fn js__sweep() -> LispObject {
     if EmacsMainJsRuntime::is_main_worker_active() {
-	inner_invokation(|scope| js_sweep_inner(scope));
+	inner_invokation(|scope| js_sweep_inner(scope), false);
 	schedule_sweep();
     }
 
     lisp::remacs_sys::Qnil
 }
 
-fn tick_js() -> Result<()> {
+fn tick_js() -> Result<bool> {
+    let mut is_complete = false;
+    let is_complete_ref = &mut is_complete;
     execute(async move {
         futures::future::poll_fn(|cx| {
             let mut worker_handle = EmacsMainJsRuntime::get_deno_worker();
             let w = worker_handle.as_mut_ref();
             let polled = w.poll_event_loop(cx);
             match polled {
-                std::task::Poll::Ready(r) => r.map_err(|e| into_ioerr(e))?,
+                std::task::Poll::Ready(r) => {
+		    *is_complete_ref = true;
+		    r.map_err(|e| into_ioerr(e))?
+		},
                 std::task::Poll::Pending => {}
             }
 
             std::task::Poll::Ready(Ok(()))
         })
         .await
-    })
+    }).map(move |_| is_complete)
 }
 
 fn init_once() -> Result<()> {
@@ -1543,6 +1567,7 @@ fn handle_error(e: std::io::Error, handler: LispObject) -> LispObject {
 }
 
 fn schedule_tick() {
+    EmacsMainJsRuntime::set_tick_scheduled(true);
     let js_options = EmacsMainJsRuntime::get_options();
     //(run-with-timer t 0.1 'js-tick-event-loop error-handler)
     let cstr = CString::new("run-with-timer").expect("Failed to create timer");
@@ -1567,26 +1592,38 @@ pub fn js_tick_event_loop(handler: LispObject) -> LispObject {
 	return lisp::remacs_sys::Qnil;
     }
 
-    schedule_tick();
+    println!("WIthin loop....");
     // If we are within the runtime, we don't want to attempt to
     // call execute, as we will error, and there really isn't anything
     // anyone can do about it. Just defer the event loop until
     // we are out of the runtime.
     if EmacsMainJsRuntime::is_within_runtime() {
+	schedule_tick();
         return lisp::remacs_sys::Qnil;
     }
 
-    let result = tick_js()
-        .map(|_| lisp::remacs_sys::Qnil)
+    let is_complete = tick_js()
         // We do NOT want to destroy the MainWorker if we error here.
         // We can still use this isolate for future promise resolutions
         // instead, just pass to the error handler.
-        .unwrap_or_else(|e| handle_error(e, handler));
-    result
+        .unwrap_or_else(|e| {
+	    handle_error(e, handler);
+	    false
+	});
+
+    if !is_complete {
+	schedule_tick();
+    } else {
+	EmacsMainJsRuntime::set_tick_scheduled(false);
+	println!("Not within loop...");
+    }
+
+    lisp::remacs_sys::Qnil
 }
 
-// @TODO we actually should call this, since it performs runtime actions.
-// for now, we are manually calling 'staticpro'
+// Do NOT call this function, it is just used for macro purposes to
+// generate variables. The user should NOT have direct access to
+// 'js-retain-map' from the scripting engine.
 #[allow(dead_code)]
 fn init_syms() {
     defvar_lisp!(Vjs_retain_map, "js-retain-map", lisp::remacs_sys::Qnil);

--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -1590,6 +1590,13 @@ pub fn js_tick_event_loop(handler: LispObject) -> LispObject {
         // We can still use this isolate for future promise resolutions
         // instead, just pass to the error handler.
         .unwrap_or_else(|e| {
+            // If handler is nil, we need to manually
+            // schedule tick since handle_error isn't
+            // going to return.
+            if handler.is_nil() {
+                schedule_tick();
+            }
+
             handle_error(e, handler);
             false
         });

--- a/rust_src/src/prelim.js
+++ b/rust_src/src/prelim.js
@@ -150,7 +150,6 @@
     // @TODO either make that time for sync customizable
     // or explore better options than hardcoding 2.5s.
     global.__sweep = () => {
-	console.log("SWEEPING...");
         const nw = [];
         const args = [];
         __weak.forEach((e) => {

--- a/rust_src/src/prelim.js
+++ b/rust_src/src/prelim.js
@@ -147,8 +147,8 @@
     // Due to this, I opt'd to use weakrefs in a map. Its nice
     // because I just need to sync that map with a lisp gc root
     // and my job is done.
-    // @TODO either make that time for sync customizable
-    // or explore better options than hardcoding 2.5s.
+    // This is called from lisp's native garbage_collect function
+    // via the lisp function (js--sweep)
     global.__sweep = () => {
         const nw = [];
         const args = [];

--- a/rust_src/src/prelim.js
+++ b/rust_src/src/prelim.js
@@ -149,7 +149,7 @@
     // and my job is done.
     // @TODO either make that time for sync customizable
     // or explore better options than hardcoding 2.5s.
-    setInterval(() => {
+    global.__sweep = () => {
         const nw = [];
         const args = [];
         __weak.forEach((e) => {
@@ -161,7 +161,7 @@
             finalize.apply(this, args);
         });
         __weak = nw;
-    }, 2500);
+    };
 
 
     // Crossing the JS -> Lisp bridge costs time, which we want to save.

--- a/rust_src/src/prelim.js
+++ b/rust_src/src/prelim.js
@@ -150,6 +150,7 @@
     // @TODO either make that time for sync customizable
     // or explore better options than hardcoding 2.5s.
     global.__sweep = () => {
+	console.log("SWEEPING...");
         const nw = [];
         const args = [];
         __weak.forEach((e) => {

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -6000,7 +6000,7 @@ garbage_collect (void)
 
   if (garbage_collection_inhibited)
     return;
-
+  Fjs__sweep();
   /* Record this function, so it appears on the profiler's backtraces.  */
   record_in_backtrace (QAutomatic_GC, 0, 0);
 


### PR DESCRIPTION
In current emacs-ng, once you initialize JavaScript, the event loop is always polling at `js-tick-rate` intervals. However, this is not needed if there are no pending module imports or promises. This just wastes CPU cycles and battery power. This patch brings us to a state of "you pay for what you use", and reduces timer usage. 

Instead, we now tick only when there are pending promises, and we increase the tick rate from 0.1 to 0.001. This addresses https://github.com/emacs-ng/emacs-ng/issues/105, and brings async performance inline with deno native, who has a much faster event loop. The user still has the ability to control the js-tick-rate if they want to lower it.

If people on lower end machines complain about 0.001 we can evaluate that default. 

Callout - Before, to cleanup lisp proxies, I ran a timer every 2.5s to sweep WeakRefs. This was kind of a hack, so I've edited the C to instead call that function when lisp's garbage collector is run. 