### PR TITLE
Allow tick rate to be controlled from scripting layer directly

### DIFF
--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -1561,7 +1561,7 @@ pub fn js_get_tick_rate() -> LispObject {
 /// to improve file read performance, decrease to preventing
 /// hitching and save battery life.
 #[lisp_fn]
-pub fn js_set_tick_rate(f: LispObject) -> LispObject {
+pub fn js_set_tick_rate(f: LispObject) {
     let mut options = EmacsMainJsRuntime::get_options();
 
     unsafe {
@@ -1569,8 +1569,6 @@ pub fn js_set_tick_rate(f: LispObject) -> LispObject {
         options.tick_rate = lisp::remacs_sys::XFLOATINT(f);
         EmacsMainJsRuntime::set_options(options);
     }
-
-    lisp::remacs_sys::Qnil
 }
 
 fn schedule_tick() {

--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -100,7 +100,7 @@ impl Default for EmacsMainJsRuntime {
 impl Default for EmacsJsOptions {
     fn default() -> Self {
         Self {
-            tick_rate: 0.001,
+            tick_rate: 0.1,
             ops: None,
             error_handler: lisp::remacs_sys::Qnil,
             inspect: None,
@@ -1548,6 +1548,29 @@ fn handle_error(e: std::io::Error, handler: LispObject) -> LispObject {
             Ffuncall(args.len().try_into().unwrap(), args.as_mut_ptr())
         }
     }
+}
+
+/// Gets the current tick rate of JavaScript.
+#[lisp_fn]
+pub fn js_get_tick_rate() -> LispObject {
+    let options = EmacsMainJsRuntime::get_options();
+    unsafe { lisp::remacs_sys::make_float(options.tick_rate) }
+}
+
+/// Sets F to be the current js tick rate. Increase this number
+/// to improve file read performance, decrease to preventing
+/// hitching and save battery life.
+#[lisp_fn]
+pub fn js_set_tick_rate(f: LispObject) -> LispObject {
+    let mut options = EmacsMainJsRuntime::get_options();
+
+    unsafe {
+        lisp::remacs_sys::CHECK_NUMBER(f);
+        options.tick_rate = lisp::remacs_sys::XFLOATINT(f);
+        EmacsMainJsRuntime::set_options(options);
+    }
+
+    lisp::remacs_sys::Qnil
 }
 
 fn schedule_tick() {


### PR DESCRIPTION
The default tick rate of 0.001 now seems to fast for me and is causing hitching. I'm going to lower it, and in an attempt to solve the issue, expose the ability to set the tick rate directly. 