### PR TITLE
Improvement of JS Event Loop Logic

### DIFF
--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "deno"
 version = "1.6.3"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#02ba0a4cc0f6038793dd33adda3823c728401f31"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#97f5395a7956d7519b3c1878c8fb906b75386474"
 dependencies = [
  "atty",
  "base64 0.12.3",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.75.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#02ba0a4cc0f6038793dd33adda3823c728401f31"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#97f5395a7956d7519b3c1878c8fb906b75386474"
 dependencies = [
  "anyhow",
  "futures",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "deno_crypto"
 version = "0.9.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#02ba0a4cc0f6038793dd33adda3823c728401f31"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#97f5395a7956d7519b3c1878c8fb906b75386474"
 dependencies = [
  "deno_core",
  "rand 0.7.3",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "deno_fetch"
 version = "0.18.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#02ba0a4cc0f6038793dd33adda3823c728401f31"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#97f5395a7956d7519b3c1878c8fb906b75386474"
 dependencies = [
  "deno_core",
  "reqwest",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "deno_runtime"
 version = "0.5.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#02ba0a4cc0f6038793dd33adda3823c728401f31"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#97f5395a7956d7519b3c1878c8fb906b75386474"
 dependencies = [
  "atty",
  "deno_core",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.26.0"
-source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#02ba0a4cc0f6038793dd33adda3823c728401f31"
+source = "git+https://github.com/DavidDeSimone/deno?branch=emacs-ng#97f5395a7956d7519b3c1878c8fb906b75386474"
 dependencies = [
  "deno_core",
  "idna",


### PR DESCRIPTION
Previous improvements to our event loop logic brought us near Deno performance for Async I/O operations, despite the fact that our event loop ticks less often. However, I found cases where emacs wouldn't tick our loop for various reason that would led to subpar performance compared to Deno.

Now I have a new approach, in which by default we loop less often, but so long as we have pending actions, we move the event loop forward in a tight loop. This improves Async I/O performance for file operations without an apparent increase in CPU usage.

While not included, I weighed adding a max time in the tight loop (i.e. do not exceed 16ms within the tight loop) to prevent hitching, but chose not to include that in this PR. It will be simple to add if we go that route. 

I've given the user control both of the tick rate, and the loops per iteration.  