### PR TITLE
Fixing issue where event would be delayed for an M-x function

### DIFF
--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -1295,6 +1295,7 @@ where
         // invokation has scheduled promises.
         if !EmacsMainJsRuntime::get_tick_scheduled() && should_schedule {
             js_tick_event_loop(lisp::remacs_sys::Qnil);
+            schedule_tick();
         }
     } else {
         let scope: &mut v8::HandleScope = unsafe { EmacsMainJsRuntime::get_stacked_v8_handle() };


### PR DESCRIPTION
The delay isn't consistent, but can happen is the right set up inputs line up. It should be a simple fix. 