### PR TITLE
Adding configure --without-javascript option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -514,6 +514,9 @@ OPTION_DEFAULT_OFF([webrender],
   [enable use of webrender(written in Rust) as GUI backend on
 multiple platforms(Linux, Windows and MacOS) (experimental)])
 
+OPTION_DEFAULT_ON([javascript],
+  [enable use of JavaScript, TypeScript, and Deno within the emacs runtime(Linux, MacOs)])
+
 ## For the times when you want to build Emacs but don't have
 ## a suitable makeinfo, and can live without the manuals.
 dnl https://lists.gnu.org/r/emacs-devel/2008-04/msg01844.html
@@ -5979,6 +5982,7 @@ AS_ECHO(["  Does Emacs use -lXaw3d?                                 ${HAVE_XAW3D
   Which dumping strategy does Emacs use?                  ${with_dumping}
   Does Emacs have native lisp compiler?                   ${HAVE_NATIVE_COMP}
   Does Emacs use webrender?                               ${with_webrender}
+  Does Emacs include JavaScript?                          ${with_javascript}
 "])
 
 if test -n "${EMACSDATA}"; then
@@ -6110,6 +6114,10 @@ case "$window_system" in
 esac
 if test "$HAVE_LIBVTERM" = "yes"; then
    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"libvterm\", "
+fi
+
+if test "${with_javascript}" = "yes"; then
+  CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"javascript\", "
 fi
 AC_SUBST(CARGO_DEFAULT_FEATURES)
 AC_CONFIG_FILES([rust_src/Cargo.toml])

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -19,9 +19,9 @@ lisp-util = { version = "0.1.0", path = "crates/lisp_util" }
 lisp-macros = { version = "0.1.0", path = "crates/lisp_macros" }
 clippy = { version = "*", optional = true }
 cfg-if = "0.1"
-deno_core = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng" }
-deno_runtime = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng" }
-deno = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng" }
+deno_core = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng", optional = true }
+deno_runtime = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng", optional = true }
+deno = { git = "https://github.com/DavidDeSimone/deno", branch = "emacs-ng", optional = true }
 crossbeam = "0.8"
 errno = "0.2"
 field-offset = "0.1"
@@ -34,11 +34,11 @@ libc = "0.2"
 line-wrap = "0.1.1"
 lsp-server = "0.5.0"
 rand = "0.6.5"
-rusty_v8 = "0.15.0"
+rusty_v8 = { version = "0.15.0", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 systemstat = "0.1"
-tokio = { version = "0.2.22", features = ["full"] }
-tokio-rustls = "0.14.1"
+tokio = { version = "0.2.22", features = ["full"], optional = true }
+tokio-rustls = { version = "0.14.1", optional = true }
 glutin = { version = "0.26", optional = true }
 gleam = { version = "0.6", optional = true }
 webrender = { version = "0.61", optional = true }
@@ -94,6 +94,7 @@ libvterm = []
 window-system-webrender = ["font-kit", "webrender", "glutin", "gleam", "app_units", "lisp/window-system-webrender"]
 # Treat warnings as a build error on Travis.
 strict = []
-
+# Use JavaScript and Deno
+javascript = ["deno", "deno_core", "deno_runtime", "tokio", "rusty_v8", "tokio-rustls"]
 # Enable glyphs debugging code.
 glyph-debug = []

--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -997,6 +997,7 @@ fn is_typescript(s: &str) -> bool {
 /// reset and reinitalized lazily. If that happens, all
 /// global state will be reset. This can be prevented by
 /// implementing a top level Promise error handler.
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "1")]
 pub fn eval_js(args: &[LispObject]) -> LispObject {
     let string_obj: LispStringRef = args[0].into();
@@ -1026,6 +1027,7 @@ pub fn eval_js(args: &[LispObject]) -> LispObject {
 /// reset and reinitalized lazily. If that happens, all
 /// global state will be reset. This can be prevented by
 /// implementing a top level Promise error handler.
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "1")]
 pub fn eval_js_file(args: &[LispObject]) -> LispObject {
     let filename: LispStringRef = args[0].into();
@@ -1064,6 +1066,7 @@ fn get_buffer_contents(mut buffer: LispObject) -> LispObject {
 /// reset and reinitalized lazily. If that happens, all
 /// global state will be reset. This can be prevented by
 /// implementing a top level Promise error handler.
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "0", intspec = "")]
 pub fn eval_js_buffer(buffer: LispObject) -> LispObject {
     let lisp_string = get_buffer_contents(buffer);
@@ -1077,6 +1080,7 @@ pub fn eval_js_buffer(buffer: LispObject) -> LispObject {
 /// reset and reinitalized lazily. If that happens, all
 /// global state will be reset. This can be prevented by
 /// implementing a top level Promise error handler.
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "0", intspec = "")]
 pub fn eval_ts_buffer(buffer: LispObject) -> LispObject {
     let lisp_string = get_buffer_contents(buffer);
@@ -1104,6 +1108,7 @@ fn get_region(start: LispObject, end: LispObject) -> LispObject {
 /// reset and reinitalized lazily. If that happens, all
 /// global state will be reset. This can be prevented by
 /// implementing a top level Promise error handler.
+#[cfg(feature = "javascript")]
 #[lisp_fn(intspec = "r")]
 pub fn eval_js_region(start: LispObject, end: LispObject) -> LispObject {
     let lisp_string = get_region(start, end);
@@ -1117,6 +1122,7 @@ pub fn eval_js_region(start: LispObject, end: LispObject) -> LispObject {
 /// reset and reinitalized lazily. If that happens, all
 /// global state will be reset. This can be prevented by
 /// implementing a top level Promise error handler.
+#[cfg(feature = "javascript")]
 #[lisp_fn(intspec = "r")]
 pub fn eval_ts_region(start: LispObject, end: LispObject) -> LispObject {
     let lisp_string = get_region(start, end);
@@ -1173,6 +1179,7 @@ pub fn eval_ts_region(start: LispObject, end: LispObject) -> LispObject {
 /// :js-tick-rate - Defaults to 0.25. This is the interval that js
 /// will evaluate if there are any resolved pending async operations
 /// and execute callbacks.
+#[cfg(feature = "javascript")]
 #[lisp_fn]
 pub fn js_initialize(args: &[LispObject]) -> LispObject {
     let ops = permissions_from_args(args);
@@ -1192,6 +1199,7 @@ fn js_initialize_inner(js_options: &EmacsJsOptions) -> Result<()> {
 
 /// Destroys the current JavaScript environment. The JavaScript environment will be
 /// reinitalized upon the next call to eval-js*, or to js-initialize
+#[cfg(feature = "javascript")]
 #[lisp_fn]
 pub fn js_cleanup() -> LispObject {
     EmacsMainJsRuntime::destroy_worker();
@@ -1281,6 +1289,7 @@ fn js_reenter_inner(scope: &mut v8::HandleScope, args: &[LispObject]) -> LispObj
     retval
 }
 
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "1")]
 pub fn js__reenter(args: &[LispObject]) -> LispObject {
     inner_invokation(move |scope| js_reenter_inner(scope, args), true)
@@ -1340,6 +1349,7 @@ where
 }
 
 /// Internal function used for cleanup. Do not call directly.
+#[cfg(feature = "javascript")]
 #[lisp_fn]
 pub fn js__clear(idx: LispObject) -> LispObject {
     inner_invokation(move |scope| js_clear_internal(scope, idx), false);
@@ -1375,6 +1385,7 @@ fn js_sweep_inner(scope: &mut v8::HandleScope) {
 }
 
 /// Internal function called by 'garbage-collect'. Do not call directly.
+#[cfg(feature = "javascript")]
 #[lisp_fn]
 pub fn js__sweep() -> LispObject {
     if EmacsMainJsRuntime::is_main_worker_active() {
@@ -1635,6 +1646,7 @@ fn handle_error(e: std::io::Error, handler: LispObject) -> LispObject {
 }
 
 /// Gets the current tick rate of JavaScript.
+#[cfg(feature = "javascript")]
 #[lisp_fn]
 pub fn js_get_tick_rate() -> LispObject {
     let options = EmacsMainJsRuntime::get_options();
@@ -1644,6 +1656,7 @@ pub fn js_get_tick_rate() -> LispObject {
 /// Sets F to be the current js tick rate. Every F seconds, javascript
 /// will attempt to evaluate the JS event loop. It will advance the
 /// event loop LOOPS_PER_TICK iterations.
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "1")]
 pub fn js_set_tick_rate(f: LispObject, loops_per_tick: LispObject) {
     let mut options = EmacsMainJsRuntime::get_options();
@@ -1712,6 +1725,7 @@ fn tick_and_handle_error(handler: LispObject) -> bool {
 /// we will advance the loop by a certain number of iterations (default 1000).
 /// This function is safe to call directly, and can even be set up to be
 /// invoked regularly with custom logic.
+#[cfg(feature = "javascript")]
 #[lisp_fn(min = "0")]
 pub fn js_tick_event_loop(handler: LispObject) -> LispObject {
     // Consume the tick for this event loop call.

--- a/rust_src/src/javascript_stubs.rs
+++ b/rust_src/src/javascript_stubs.rs
@@ -1,0 +1,15 @@
+#[cfg(not(feature = "javascript"))]
+use lisp::lisp::LispObject;
+#[cfg(not(feature = "javascript"))]
+use lisp::remacs_sys::Qnil;
+#[cfg(not(feature = "javascript"))]
+use lisp_macros::lisp_fn;
+
+// This file is used to stub out functions when emacs-ng is compiled without javascript
+#[cfg(not(feature = "javascript"))]
+#[lisp_fn]
+pub fn js__sweep() -> LispObject {
+    Qnil
+}
+
+include!(concat!(env!("OUT_DIR"), "/javascript_stubs_exports.rs"));

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -36,12 +37,17 @@ extern crate lsp_server;
 #[macro_use]
 extern crate serde_json;
 extern crate crossbeam;
+#[cfg(feature = "javascript")]
 extern crate deno;
+#[cfg(feature = "javascript")]
 extern crate deno_core;
+#[cfg(feature = "javascript")]
 extern crate deno_runtime;
 // TODO: enable after #111 is fixed
 // extern crate git2;
+#[cfg(feature = "javascript")]
 extern crate rusty_v8;
+#[cfg(feature = "javascript")]
 extern crate tokio;
 
 #[macro_use]
@@ -61,7 +67,9 @@ macro_rules! export_lisp_fns {
 }
 
 mod git;
+#[cfg(feature = "javascript")]
 mod javascript;
+mod javascript_stubs;
 mod ng_async;
 mod parsing;
 
@@ -72,6 +80,12 @@ mod wrterm;
 
 #[cfg(feature = "window-system-webrender")]
 pub use crate::wrterm::{tip_frame, wr_display_list};
+
+#[cfg(not(feature = "javascript"))]
+mod javascript {
+    include!(concat!(env!("OUT_DIR"), "/javascript_exports.rs"));
+}
+
 
 #[cfg(not(test))]
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -86,6 +86,5 @@ mod javascript {
     include!(concat!(env!("OUT_DIR"), "/javascript_exports.rs"));
 }
 
-
 #[cfg(not(test))]
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));

--- a/rust_src/src/parsing.rs
+++ b/rust_src/src/parsing.rs
@@ -517,6 +517,7 @@ pub fn json_de(args: &[LispObject]) -> LispObject {
     }
 }
 
+#[cfg(feature = "javascript")]
 pub(crate) fn gen_ser_deser_config() -> JSONConfiguration {
     JSONConfiguration {
         null_obj: Qnil,
@@ -524,6 +525,7 @@ pub(crate) fn gen_ser_deser_config() -> JSONConfiguration {
     }
 }
 
+#[cfg(feature = "javascript")]
 pub(crate) fn deser(string: &str, config: Option<JSONConfiguration>) -> Result<LispObject> {
     let val = serde_json::from_str(string)?;
     let config = config.unwrap_or_else(|| gen_ser_deser_config());
@@ -531,6 +533,7 @@ pub(crate) fn deser(string: &str, config: Option<JSONConfiguration>) -> Result<L
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
 }
 
+#[cfg(feature = "javascript")]
 pub(crate) fn ser(o: LispObject) -> Result<String> {
     let config = gen_ser_deser_config();
     let value = lisp_to_serde(o, &config)


### PR DESCRIPTION
Fixes https://github.com/emacs-ng/emacs-ng/issues/130

This PR has made me really want to refactor `#[lisp_fn]`. Unless I'm missing something, it seems like it's really painful to deal with lisp_fn combined with condition includes, since docstring.rs will just parse anything it sees as a rust file, even if it's not included as a module in lib.rs 