### PR TITLE
Adds eval-js-expression and eval-js-literally

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -35,8 +35,7 @@ Now we go back to \*scratch\* and run
 
 This is a relative filepath, and it works off of emacs current working directory (cwd). If you are in doubt to what emacs cwd is, just run the lisp function `(pwd)` in the lisp scratchpad
 
-You should see "Hello TypeScript" printed. All of the eval-js* functions return nil. If you want to use a calculated value from JavaScript/TypeScript in Lisp, you can either set a variable (via `lisp.setq`, or call a lisp function with it as an argument.
-
+You should see "Hello TypeScript" printed. All of the eval-js* functions return nil. If you want to use a calculated value from JavaScript in Lisp, you should use `eval-js-literally`. If you are looking for something like `eval-expression`, which is normally bound to M-:, you should use `eval-js-expression`. It accepts the same arguments as `eval-expression`, except with the first argument being a JavaScript expression, and behaves very similarly to `eval-expression`. It will also inserts the results into `values` just like `eval-expression`. `eval-js-literally` and `eval-js-expression` do not work with TypeScript at this time.
 
 ## Iteration
 

--- a/rust_src/src/prelim.js
+++ b/rust_src/src/prelim.js
@@ -39,6 +39,12 @@
 
     global.__clear = (idx) => { __functions[idx] = null; };
 
+    global.__eval = (str) => {
+	const evalResult = (1,eval)(str);
+	const retval = processArgs([evalResult]);
+	return retval[0];
+    };
+
     const makeHashTable = (a) => {
 	let x = lisp.make_hash_table();
 	for (k in a) {


### PR DESCRIPTION
This PR adds a very requested feature, which is the equivalent of M-: but for JavaScript. This also adds `eval-js-literally`, which will actually return the value of the JavaScript expression, unlike eval-js-* which always returns nil. This will auto-translate proxys, meaning that things like:

`(eval-js-literally "lisp.current_buffer()")` works how you would hope it does - it will actually return the current buffer as a lisp object. 

It seems like we should bind `eval-js-expression` to a key binding, but I'm unsure what a good default, if any, would be. I'm open to suggestions. 

These functions will ONLY work with JavaScript. Adding TS support won't be hard, but I want to wait until https://github.com/emacs-ng/emacs-ng/issues/118 lands, because Deno 1.7 reworked their interface to compile TS at runtime (Deno.compile vs Deno.emit). 