### PR TITLE
Fix JS error propogation in JS defuns. Fix panic when calling json() on functions. 

### DIFF
--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -373,6 +373,17 @@ macro_rules! make_proxy {
     }};
 }
 
+macro_rules! unproxy {
+    ($scope:expr, $obj:expr) => {{
+        let internal = $obj.get_internal_field($scope, 0).unwrap();
+        let ptrstr = internal
+            .to_string($scope)
+            .unwrap()
+            .to_rust_string_lossy($scope);
+        LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap())
+    }};
+}
+
 fn throw_exception_with_error<E: std::error::Error>(scope: &mut v8::HandleScope, e: E) {
     let error_string = e.to_string();
     let error = v8::String::new(scope, &error_string).unwrap();
@@ -472,6 +483,13 @@ pub fn lisp_make_lambda(
 
     let llen = unsafe { lisp::remacs_sys::make_fixnum(len.into()) };
 
+    // WHAT IS THIS?!
+    // This is doing the following in native code:
+    // (lambda (&REST) (js--reenter llen (make-finalizer (lambda () js--clear llen)) REST))
+    // To walk through it, this is a lambda that will call js--reenter with the index of our
+    // js lambda. In order to clean all this garbage up, we make a finalizer that will call
+    // js--clear to null out that lambda, to 'release' it from the JS GC. JS lambdas bound
+    // this way just live in a global array, and js--clear just removes them from that array.
     let finalizer = unsafe {
         let mut bound = vec![lisp::remacs_sys::Qjs__clear, llen];
         let list = lisp::remacs_sys::Flist(bound.len().try_into().unwrap(), bound.as_mut_ptr());
@@ -568,18 +586,8 @@ pub fn lisp_intern(
     args: v8::FunctionCallbackArguments,
     mut retval: v8::ReturnValue,
 ) {
-    let a = args.get(0).to_object(scope).unwrap();
-    assert!(a.internal_field_count() > 0);
-    let internal = a.get_internal_field(scope, 0).unwrap();
-    let ptrstr = internal
-        .to_string(scope)
-        .unwrap()
-        .to_rust_string_lossy(scope);
-    let lispobj =
-        LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
-
+    let lispobj = unproxy!(scope, args.get(0).to_object(scope).unwrap());
     let result = unsafe { lisp::remacs_sys::Fintern(lispobj, lisp::remacs_sys::Qnil) };
-
     let proxy = make_proxy!(scope, result);
     let r = v8::Local::<v8::Value>::try_from(proxy).unwrap();
     retval.set(r);
@@ -609,15 +617,7 @@ pub fn lisp_list(
                 }
             }
         } else if arg.is_object() {
-            let a = arg.to_object(scope).unwrap();
-            assert!(a.internal_field_count() > 0);
-            let internal = a.get_internal_field(scope, 0).unwrap();
-            let ptrstr = internal
-                .to_string(scope)
-                .unwrap()
-                .to_rust_string_lossy(scope);
-            let lispobj =
-                LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
+            let lispobj = unproxy!(scope, arg.to_object(scope).unwrap());
             lisp_args.push(lispobj);
         } else {
             let error = v8::String::new(scope, "Invalid arguments passed to lisp_invoke. Valid options are String, Function, or Proxy Object").unwrap();
@@ -644,15 +644,7 @@ pub fn lisp_json(
 ) {
     let mut parsed = false;
     if args.get(0).is_object() {
-        let a = args.get(0).to_object(scope).unwrap();
-        assert!(a.internal_field_count() > 0);
-        let internal = a.get_internal_field(scope, 0).unwrap();
-        let ptrstr = internal
-            .to_string(scope)
-            .unwrap()
-            .to_rust_string_lossy(scope);
-        let lispobj =
-            LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
+        let lispobj = unproxy!(scope, args.get(0).to_object(scope).unwrap());
         if let Ok(json) = crate::parsing::ser(lispobj) {
             parsed = true;
             let r =
@@ -680,15 +672,7 @@ pub fn finalize(
     for i in 0..len {
         let arg = args.get(i);
         if arg.is_object() {
-            let a = arg.to_object(scope).unwrap();
-            assert!(a.internal_field_count() > 0);
-            let internal = a.get_internal_field(scope, 0).unwrap();
-            let ptrstr = internal
-                .to_string(scope)
-                .unwrap()
-                .to_rust_string_lossy(scope);
-            let lispobj =
-                LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
+            let lispobj = unproxy!(scope, arg.to_object(scope).unwrap());
             new_list = LispObject::cons(lispobj, new_list);
         }
     }
@@ -732,16 +716,7 @@ pub fn lisp_callback(
 ) {
     let mut lisp_args = vec![];
     let len = args.length();
-
-    let a = args.get(0).to_object(scope).unwrap();
-    assert!(a.internal_field_count() > 0);
-    let internal = a.get_internal_field(scope, 0).unwrap();
-    let ptrstr = internal
-        .to_string(scope)
-        .unwrap()
-        .to_rust_string_lossy(scope);
-    let lispobj =
-        LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
+    let lispobj = unproxy!(scope, args.get(0).to_object(scope).unwrap());
     lisp_args.push(lispobj);
 
     for i in 1..len {
@@ -761,15 +736,7 @@ pub fn lisp_callback(
                 }
             }
         } else if arg.is_object() {
-            let a = arg.to_object(scope).unwrap();
-            assert!(a.internal_field_count() > 0);
-            let internal = a.get_internal_field(scope, 0).unwrap();
-            let ptrstr = internal
-                .to_string(scope)
-                .unwrap()
-                .to_rust_string_lossy(scope);
-            let lispobj =
-                LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
+            let lispobj = unproxy!(scope, arg.to_object(scope).unwrap());
             lisp_args.push(lispobj);
         } else {
             let error = v8::String::new(scope, "Invalid arguments passed to lisp_invoke. Valid options are String, Function, or Proxy Object").unwrap();
@@ -1115,16 +1082,7 @@ fn eval_literally_inner(scope: &mut v8::HandleScope, js: LispStringRef) -> LispO
                 }
             }
         } else if result.is_object() {
-            let a = result.to_object(scope).unwrap();
-            assert!(a.internal_field_count() > 0);
-            let internal = a.get_internal_field(scope, 0).unwrap();
-            let ptrstr = internal
-                .to_string(scope)
-                .unwrap()
-                .to_rust_string_lossy(scope);
-            let lispobj =
-                LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
-            retval = lispobj;
+            retval = unproxy!(scope, result.to_object(scope).unwrap());
         }
     }
 
@@ -1397,16 +1355,7 @@ fn js_reenter_inner(scope: &mut v8::HandleScope, args: &[LispObject]) -> Result<
 
             retval = crate::parsing::deser(&a, None)?;
         } else if result.is_object() {
-            let a = result.to_object(tc_scope).unwrap();
-            assert!(a.internal_field_count() > 0);
-            let internal = a.get_internal_field(tc_scope, 0).unwrap();
-            let ptrstr = internal
-                .to_string(tc_scope)
-                .unwrap()
-                .to_rust_string_lossy(tc_scope);
-            let lispobj =
-                LispObject::from_C_unsigned(ptrstr.parse::<lisp::remacs_sys::EmacsUint>().unwrap());
-            retval = lispobj;
+            retval = unproxy!(tc_scope, result.to_object(tc_scope).unwrap());
         }
     } else {
         // From https://github.com/denoland/deno/core/runtime.js

--- a/rust_src/src/parsing.rs
+++ b/rust_src/src/parsing.rs
@@ -281,10 +281,14 @@ fn lisp_to_serde(
             // We only will add to the map if a value is not present
             // at that key
             if !map.contains_key(&key_utf8) {
-                if let Ok(insert_value) = lisp_to_serde(value, config) {
-                    map.insert(key_utf8, insert_value);
-                } else {
-                    return_none = true;
+                match lisp_to_serde(value, config) {
+                    Ok(insert_value) => {
+                        map.insert(key_utf8, insert_value);
+                    }
+                    Err(e) => {
+                        reason = e.to_string();
+                        return_none = true;
+                    }
                 }
             }
         });

--- a/test/js/errors.js
+++ b/test/js/errors.js
@@ -1,0 +1,56 @@
+export function errors() {
+    return Promise.resolve()
+	.test(() => {
+	    try {
+		lisp.cons();
+	    } catch (e) {
+		if (!e) {
+		    throw new Error("lisp.cons() failed to throw");
+		}
+	    }
+	})
+	.test(() => {
+	    let sent = null;
+	    const failure = 'fail';
+	    lisp.defun({
+		name: "ng-test--toplevel",
+		func: () => {
+		    lisp.ng_test__low_inner();
+		    sent = failure;
+		}
+	    });
+
+	    lisp.defun({
+		name: "ng-test--low-inner",
+		func: () => {
+		    lisp.ng_test__deep_inner();
+		    sent = failure;
+		}
+	    });
+
+	    lisp.defun({
+		name: "ng-test--deep-inner",
+		func: () => {
+		    throw new Error("Intentional");
+		}
+	    });
+
+	    let caught = false;
+	    try {
+		lisp.ng_test__toplevel();
+	    } catch (e) {
+		caught = true;
+		if (!e) {
+		    throw new Error("Failed to catch error..");
+		}
+
+		if (!!sent) {
+		    throw new Error("Failed to early out.");
+		}
+	    }
+
+	    if (!caught) {
+		throw new Error("Did not throw error within defun");
+	    }
+	});
+};

--- a/test/js/errors.js
+++ b/test/js/errors.js
@@ -52,5 +52,37 @@ export function errors() {
 	    if (!caught) {
 		throw new Error("Did not throw error within defun");
 	    }
+	})
+	.test(() => {
+	    let thrown = false;
+	    try {
+		lisp.make.string('\0');
+	    } catch(e) {
+		thrown = true;
+		if (!e) {
+		    throw new Error("Nul byte in string did not error");
+		}
+	    }
+
+	    if (!thrown) {
+		throw new Error("Nul byte did not throw");
+	    }
+	})
+	.test(() => {
+	    lisp.defun({
+		name: "ng-test--fx--1",
+		func: (callback) => {
+		    callback.json();
+		}
+	    });
+
+	    lisp.defun({
+		name: "ng-test--fx--2",
+		func: () => {
+		    lisp.ng_test__fx__1(() => console.log('foo'));
+		}
+	    });
+
+	    lisp.ng_test__fx__2();
 	});
 };

--- a/test/js/main.js
+++ b/test/js/main.js
@@ -3,6 +3,7 @@ import { basicLisp } from "./basicLisp.js";
 import { webWorkers } from "./webWorkers.js";
 import { webAsm } from "./webAsm.js";
 import { basicTyping } from "./basicTyping.ts";
+import { errors } from "./errors.js";
 
 let counter = 1;
 Promise.prototype.test = function(f) {
@@ -21,6 +22,7 @@ Promise.all([
     webWorkers(),
     webAsm(),
     basicTyping(),
+    errors(),
 ])
     .then(() => {
 	console.log("JS Tests Complete, No Errors");


### PR DESCRIPTION
Marking this as WIP as I still need to write some tests for this patch. I also want to improve the logic for parsing::deser and parsing::ser. One returns a result, and one returns an option - it's messy in general. Both can error on certain inputs, which causes issues. 

This patch addresses some real edge cases with error handling, like if an error happens when you are in a JS -> LISP -> JS -> LISP -> JS -> LISP type callstack. 

- [x] Added tests for 'advanced' error handling
- [x] Improve ser/deser API 