### PR TITLE
gitter: link to room overview instead of community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://badges.gitter.im/emacs-ng/emacs-ng.svg)](https://gitter.im/emacsng/community)
+[![](https://badges.gitter.im/emacs-ng/emacs-ng.svg)](https://gitter.im/emacsng)
 [![](https://github.com/emacs-ng/emacs-ng/workflows/CI/badge.svg)](https://github.com/emacs-ng/emacs-ng/actions?query=workflow%3ACI)
 [![](https://img.shields.io/reddit/subreddit-subscribers/emacsng?label=Join%20r%2Femacsng&style=social)](https://www.reddit.com/r/emacsng/)
 


### PR DESCRIPTION
Since we have more conversations on gitter, I think it makes sense to link to the channel overview instead of the community room. I added a webrender room(https://gitter.im/emacsng/webrender). Feel free to open additional rooms.