### PR TITLE
javascript.rs cleanup

### DIFF
--- a/rust_src/src/javascript.rs
+++ b/rust_src/src/javascript.rs
@@ -410,6 +410,14 @@ macro_rules! unproxy {
     }};
 }
 
+macro_rules! bind_global_fn {
+    ($scope:expr, $global: expr, $fnc:ident) => {{
+        let name = v8::String::new($scope, stringify!($fnc)).unwrap();
+        let func = v8::Function::new($scope, $fnc).unwrap();
+        $global.set($scope, name.into(), func.into());
+    }};
+}
+
 fn throw_exception_with_error<E: std::error::Error>(scope: &mut v8::HandleScope, e: E) {
     let error_string = e.to_string();
     let error = v8::String::new(scope, &error_string).unwrap();
@@ -735,7 +743,7 @@ unsafe extern "C" fn lisp_handler(
     LispObject::cons(lisp::remacs_sys::Qjs_lisp_error, arg2)
 }
 
-pub fn lisp_callback(
+pub fn lisp_invoke(
     mut scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
     mut retval: v8::ReturnValue,
@@ -1014,11 +1022,14 @@ pub fn eval_js(args: &[LispObject]) -> LispObject {
 #[lisp_fn(intspec = "MEval JS: ")]
 pub fn eval_js_literally(js: LispStringRef) -> LispObject {
     let ops = EmacsMainJsRuntime::get_options();
-    js_initialize_inner(&ops).unwrap_or_else(|e| {
+    js_init_sys("init.js", &ops).unwrap_or_else(|e| {
         error!("JS Failed to initialize with error: {}", e);
     });
-    inner_invokation(move |scope| eval_literally_inner(scope, js), true)
-        .unwrap_or_else(|e| handle_error_inner_invokation(e))
+
+    let result = execute_with_current_scope(move |scope| eval_literally_inner(scope, js))
+        .unwrap_or_else(|e| handle_error_inner_invokation(e));
+    tick_and_schedule_if_required();
+    result
 }
 
 /// Evaluate the contents of BUFFER as JavaScript
@@ -1270,16 +1281,16 @@ pub fn eval_ts_region(start: LispObject, end: LispObject) -> LispObject {
 pub fn js_initialize(args: &[LispObject]) -> LispObject {
     let ops = permissions_from_args(args);
     EmacsMainJsRuntime::set_options(ops.clone());
-    js_initialize_inner(&ops)
+    js_init_sys("init.js", &ops)
         .map(|_| lisp::remacs_sys::Qt)
         .unwrap_or_else(|e| {
             error!("JS Failed to initialize with error: {}", e);
         })
 }
 
-fn js_initialize_inner(js_options: &EmacsJsOptions) -> Result<()> {
-    init_once()?;
-    init_worker("init.js", js_options)?;
+fn js_init_sys(filename: &str, js_options: &EmacsJsOptions) -> Result<()> {
+    init_tokio()?;
+    init_worker(filename, js_options)?;
     Ok(())
 }
 
@@ -1400,6 +1411,12 @@ fn execute_function_may_throw(
     Ok(retval)
 }
 
+fn tick_and_schedule_if_required() {
+    if !EmacsMainJsRuntime::is_within_runtime() && !EmacsMainJsRuntime::get_tick_scheduled() {
+        js_tick_event_loop(lisp::remacs_sys::Qnil);
+    }
+}
+
 fn handle_error_inner_invokation(e: std::io::Error) -> LispObject {
     if !EmacsMainJsRuntime::is_within_runtime() {
         let js_options = EmacsMainJsRuntime::get_options();
@@ -1417,8 +1434,10 @@ fn handle_error_inner_invokation(e: std::io::Error) -> LispObject {
 #[cfg(feature = "javascript")]
 #[lisp_fn(min = "1")]
 pub fn js__reenter(args: &[LispObject]) -> LispObject {
-    inner_invokation(move |scope| js_reenter_inner(scope, args), true)
-        .unwrap_or_else(|e| handle_error_inner_invokation(e))
+    let result = execute_with_current_scope(move |scope| js_reenter_inner(scope, args))
+        .unwrap_or_else(|e| handle_error_inner_invokation(e));
+    tick_and_schedule_if_required();
+    result
 }
 
 fn js_clear_internal(scope: &mut v8::HandleScope, idx: LispObject) {
@@ -1442,30 +1461,23 @@ fn js_clear_internal(scope: &mut v8::HandleScope, idx: LispObject) {
     fnc.call(scope, recv, v8_args.as_slice()).unwrap();
 }
 
-fn inner_invokation<F, R: Sized>(f: F, should_schedule: bool) -> R
+fn execute_with_current_scope<F, R: Sized>(f: F) -> R
 where
     F: Fn(&mut v8::HandleScope) -> R,
 {
     let result;
     if !EmacsMainJsRuntime::is_within_runtime() {
-        {
+        result = block_on(async move {
             let mut worker_handle = EmacsMainJsRuntime::get_deno_worker();
             let worker = worker_handle.as_mut_ref();
             let runtime = &mut worker.js_runtime;
             let context = runtime.global_context();
             let scope = &mut v8::HandleScope::with_context(runtime.v8_isolate(), context);
-            let mut handle = EmacsMainJsRuntime::get_tokio_handle();
-            let handle_ref = handle.as_mut_ref();
-            EmacsMainJsRuntime::enter_runtime();
-            result = handle_ref.block_on(async move { f(scope) });
-            EmacsMainJsRuntime::exit_runtime();
-        }
-        // Only in the case that the event loop as gone to sleep,
-        // we want to reinvoke it, in case the above
-        // invokation has scheduled promises.
-        if !EmacsMainJsRuntime::get_tick_scheduled() && should_schedule {
-            js_tick_event_loop(lisp::remacs_sys::Qnil);
-        }
+            let retval = f(scope);
+
+            Ok(retval)
+        })
+        .unwrap(); // Safe due to the fact we set this to Ok
     } else {
         let scope: &mut v8::HandleScope = unsafe { EmacsMainJsRuntime::get_stacked_v8_handle() };
         result = f(scope);
@@ -1479,7 +1491,7 @@ where
 #[cfg(feature = "javascript")]
 #[lisp_fn]
 pub fn js__clear(idx: LispObject) -> LispObject {
-    inner_invokation(move |scope| js_clear_internal(scope, idx), false);
+    execute_with_current_scope(move |scope| js_clear_internal(scope, idx));
     lisp::remacs_sys::Qnil
 }
 
@@ -1487,7 +1499,7 @@ fn into_ioerr<E: Into<Box<dyn std::error::Error + Send + Sync>>>(e: E) -> std::i
     std::io::Error::new(std::io::ErrorKind::Other, e)
 }
 
-fn execute<T: Sized + std::future::Future<Output = Result<()>>>(fnc: T) -> Result<()> {
+fn block_on<R: Sized, T: Sized + std::future::Future<Output = Result<R>>>(fnc: T) -> Result<R> {
     if EmacsMainJsRuntime::is_within_runtime() {
         Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -1520,7 +1532,7 @@ fn js_sweep_inner(scope: &mut v8::HandleScope) {
 #[lisp_fn]
 pub fn js__sweep() -> LispObject {
     if EmacsMainJsRuntime::is_main_worker_active() {
-        inner_invokation(|scope| js_sweep_inner(scope), false);
+        execute_with_current_scope(|scope| js_sweep_inner(scope));
     }
 
     lisp::remacs_sys::Qnil
@@ -1529,7 +1541,7 @@ pub fn js__sweep() -> LispObject {
 fn tick_js() -> Result<bool> {
     let mut is_complete = false;
     let is_complete_ref = &mut is_complete;
-    execute(async move {
+    block_on(async move {
         futures::future::poll_fn(|cx| {
             let mut worker_handle = EmacsMainJsRuntime::get_deno_worker();
             let w = worker_handle.as_mut_ref();
@@ -1549,7 +1561,7 @@ fn tick_js() -> Result<bool> {
     .map(move |_| is_complete)
 }
 
-fn init_once() -> Result<()> {
+fn init_tokio() -> Result<()> {
     if !EmacsMainJsRuntime::is_tokio_active()
     // Needed in the case that the tokio runtime is being taken
     // for completing a JS operation
@@ -1629,66 +1641,18 @@ fn init_worker(filepath: &str, js_options: &EmacsJsOptions) -> Result<()> {
                 let obj = v8::Object::new(scope);
                 global.set(scope, name.into(), obj.into());
             }
-            {
-                let name = v8::String::new(scope, "lisp_invoke").unwrap();
-                let func = v8::Function::new(scope, lisp_callback).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "is_proxy").unwrap();
-                let func = v8::Function::new(scope, is_proxy).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "finalize").unwrap();
-                let func = v8::Function::new(scope, finalize).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_json").unwrap();
-                let func = v8::Function::new(scope, lisp_json).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_intern").unwrap();
-                let func = v8::Function::new(scope, lisp_intern).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_make_finalizer").unwrap();
-                let func = v8::Function::new(scope, lisp_make_finalizer).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_string").unwrap();
-                let func = v8::Function::new(scope, lisp_string).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_fixnum").unwrap();
-                let func = v8::Function::new(scope, lisp_fixnum).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_float").unwrap();
-                let func = v8::Function::new(scope, lisp_float).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_make_lambda").unwrap();
-                let func = v8::Function::new(scope, lisp_make_lambda).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "lisp_list").unwrap();
-                let func = v8::Function::new(scope, lisp_list).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
-            {
-                let name = v8::String::new(scope, "json_lisp").unwrap();
-                let func = v8::Function::new(scope, json_lisp).unwrap();
-                global.set(scope, name.into(), func.into());
-            }
+            bind_global_fn!(scope, global, lisp_invoke);
+            bind_global_fn!(scope, global, is_proxy);
+            bind_global_fn!(scope, global, finalize);
+            bind_global_fn!(scope, global, lisp_json);
+            bind_global_fn!(scope, global, lisp_intern);
+            bind_global_fn!(scope, global, lisp_make_finalizer);
+            bind_global_fn!(scope, global, lisp_string);
+            bind_global_fn!(scope, global, lisp_fixnum);
+            bind_global_fn!(scope, global, lisp_float);
+            bind_global_fn!(scope, global, lisp_make_lambda);
+            bind_global_fn!(scope, global, lisp_list);
+            bind_global_fn!(scope, global, json_lisp);
         }
         {
             runtime
@@ -1710,10 +1674,9 @@ fn run_module_inner(
     js_options: &EmacsJsOptions,
     as_typescript: bool,
 ) -> Result<LispObject> {
-    init_once()?;
-    init_worker(filepath, js_options)?;
+    js_init_sys(filepath, js_options)?;
 
-    execute(async move {
+    block_on(async move {
         let mut worker_handle = EmacsMainJsRuntime::get_deno_worker();
         let w = worker_handle.as_mut_ref();
         let main_module =

--- a/test/js/basicLisp.js
+++ b/test/js/basicLisp.js
@@ -1,6 +1,6 @@
 export function basicLisp() {
     return Promise.resolve()
-	.test(() => {
+	.test('lispAllocations', () => {
 	    let plist = lisp.make.plist({x: 3, y: 4, z: lisp.symbols.qqz});
 	    let alist = lisp.make.alist({s: 5, y: "Hello World", z: lisp.symbols.qq});
 
@@ -20,7 +20,7 @@ export function basicLisp() {
 		throw new Error("Failed to fetch list item properly");
 	    }
 	})
-	.test(() => {
+	.test('symbols', () => {
 	    let p = lisp.symbols.a;
 	    let qq = lisp.symbols.qq;
 	    let qc = lisp.keywords.word;
@@ -30,13 +30,13 @@ export function basicLisp() {
 		throw new Error("Failure in test lisp.setq");
 	    }
 	})
-	.test(() => {
+	.test('timers', () => {
 	    return new Promise((resolve, reject) => {
 		let timer = lisp.run_with_timer(1, lisp.symbols.nil, () => resolve());
 		setTimeout(() => reject("Failure to execute simple timer."), 5000);
 	    });
 	})
-	.test(() => {
+	.test('basicDefun', () => {
 	    let mutated = 0;
 	    let myFunc = lisp.defun("hello", (arg, arg2) => {
 		mutated = arg;
@@ -69,10 +69,10 @@ export function basicLisp() {
 		throw new Error("Failure in test Defun: Mutated value not set from callback");
 	    }
 	})
-	.test(() => {
+	.test('pipeProcess', () => {
 	    lisp.make_pipe_process(lisp.keywords.name, "mybuff");
 	})
-	.test(() => {
+	.test('setqLogic', () => {
 	    lisp.let((a) => {
 		if (a !== 3) {
 		    throw new Error("Arguments do not match");
@@ -85,7 +85,7 @@ export function basicLisp() {
 		}
 	    }, 3);
 	})
-	.test(() => {
+	.test('withCurrentBuffer', () => {
 	    let buf = lisp.get_buffer_create("mybuff");
 	    let buf2 = lisp.get_buffer_create("mybuff2");
 	    lisp.set_buffer(buf2);
@@ -108,7 +108,7 @@ export function basicLisp() {
 		throw new Error("with-current-buffer did not properly retain buffer state");
 	    }
 	})
-	.test(() => {
+	.test('bufferString', () => {
 	    let executed = false;
 	    lisp.with_temp_buffer(() => {
 		executed = true;
@@ -123,7 +123,7 @@ export function basicLisp() {
 		throw new Error("with-temp-buffer failed to execute");
 	    }
 	})
-	.test(async () => {
+	.test('denoAdditions', async () => {
 	    const minPowTwo = 2;
 	    const maxPowTwo = 1024 * 64;
 

--- a/test/js/bootstrap.el
+++ b/test/js/bootstrap.el
@@ -2,10 +2,6 @@
 (setenv "DENO_DIR" "test/js/")
 (js-initialize :js-error-handler 'handler)
 (eval-js-file "./js/main.js")
-;; Since we are in batch
-;; manually tick the event
-;; loop
-(run-with-timer t 0.1 'js-tick-event-loop 'handler)
 ;; Since we are running async tests, we want to keep the event loop
 ;; running to allow them to finish. We will manually
 ;; exit the program upon completion

--- a/test/js/errors.js
+++ b/test/js/errors.js
@@ -1,6 +1,6 @@
 export function errors() {
     return Promise.resolve()
-	.test(() => {
+	.test('consThrow', () => {
 	    try {
 		lisp.cons();
 	    } catch (e) {
@@ -9,7 +9,7 @@ export function errors() {
 		}
 	    }
 	})
-	.test(() => {
+	.test('errorPropagation', () => {
 	    let sent = null;
 	    const failure = 'fail';
 	    lisp.defun({
@@ -53,7 +53,7 @@ export function errors() {
 		throw new Error("Did not throw error within defun");
 	    }
 	})
-	.test(() => {
+	.test('nullTerminatorInString', () => {
 	    let thrown = false;
 	    try {
 		lisp.make.string('\0');
@@ -68,7 +68,7 @@ export function errors() {
 		throw new Error("Nul byte did not throw");
 	    }
 	})
-	.test(() => {
+	.test('functionJson', () => {
 	    lisp.defun({
 		name: "ng-test--fx--1",
 		func: (callback) => {
@@ -85,7 +85,7 @@ export function errors() {
 
 	    lisp.ng_test__fx__2();
 	})
-	.test(() => {
+	.test('evalJsLiterally', () => {
 	    const result = lisp.eval_js_literally('3');
 	    if (result !== 3) {
 		throw new Error("Failed to literally eval JS");

--- a/test/js/helloWorld.js
+++ b/test/js/helloWorld.js
@@ -1,4 +1,4 @@
 export function helloWorld() {
     return Promise.resolve()
-	.test(() => console.log('Hello World'));
+	.test('helloWorld', () => console.log('Hello World'));
 };

--- a/test/js/main.js
+++ b/test/js/main.js
@@ -5,12 +5,12 @@ import { webAsm } from "./webAsm.js";
 import { basicTyping } from "./basicTyping.ts";
 import { errors } from "./errors.js";
 
-let counter = 1;
-Promise.prototype.test = function(f) {
-    return this.then(f)
+Promise.prototype.test = function(name, f) {
+    let now = Date.now();
+    return this.then(() => { now = Date.now() })
+	.then(f)
 	.then((result) => {
-	    counter += 1;
-	    console.log("Passed Test ... " + counter);
+	    console.log(`Passed Test ${name} ... (${Date.now() - now} ms)`);
 	    return result;
 	});
 

--- a/test/js/webAsm.js
+++ b/test/js/webAsm.js
@@ -1,6 +1,6 @@
 export function webAsm() {
     return Promise.resolve()
-	.test(() => {
+	.test('basicWebAsm', () => {
 	    const wasmCode = new Uint8Array([
 		0, 97, 115, 109, 1, 0, 0, 0, 1, 133, 128, 128, 128, 0, 1, 96, 0, 1, 127,
 		3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0,

--- a/test/js/webWorkers.js
+++ b/test/js/webWorkers.js
@@ -1,6 +1,6 @@
 export function webWorkers() {
     return Promise.resolve()
-	.test(() => {
+	.test('webWorkerTest', () => {
 	    let worker = new Worker(new URL("webWorkerModule.js", import.meta.url).href,
 				    { type: "module",
 				      deno: true,


### PR DESCRIPTION
~~WIP, dependent on https://github.com/emacs-ng/emacs-ng/pull/170 landing first~~

I might add things to this list between now and that PR landing, but this is my starting off point. This PR shouldn't actually change any behavior, it should just be a refactor. 

Goals:

- [x] Remove mem::transmute usage
- [x] Rename the (horrible) naming of the get_v8_stacked_handle and get_v8_raw_handle functions 
- [x] Better documents the assumptions of the v8_handle stack that must be maintained
- [x] Remove duplication across inner_invokation and execute
  - [x] Rename execute and inner_invokation to better reflect what both are actually doing 
- [x] Reduce boilerplate of binding global functions with a macro 
- [x]  Rename init_once to init_tokio
- [x] Rename js_initialize_inner to something more generic since we call it outside of js_initialize