### PR TITLE
Restructure generated source to make emacsng work with rust-analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,7 @@ src/gdb.ini
 /var/
 
 rust_src/Cargo.toml
+
+rust_src/crates/lisp/src/bindings.rs
+rust_src/crates/lisp/src/globals.rs
+rust_src/crates/lisp/src/definitions.rs

--- a/rust_src/crates/lisp/src/lib.rs
+++ b/rust_src/crates/lisp/src/lib.rs
@@ -27,6 +27,9 @@ pub mod eval_macros;
 #[macro_use]
 pub mod vector_macros;
 pub mod lisp;
+pub mod definitions;
+pub mod bindings;
+pub mod globals;
 
 pub mod eval;
 pub mod font;

--- a/rust_src/crates/lisp/src/remacs_sys.rs
+++ b/rust_src/crates/lisp/src/remacs_sys.rs
@@ -20,14 +20,14 @@ use std::mem;
 
 use libc::timespec;
 
-use crate::lisp::LispObject;
 
-include!("../../../generated/definitions.rs");
+pub use crate::{definitions::*, lisp::LispObject};
 
 type Lisp_Object = LispObject;
 
-include!("../../../generated/bindings.rs");
-include!("../../../generated/globals.rs");
+pub use crate::{bindings::*, globals::*};
+pub use crate::bindings;
+pub use crate::globals;
 
 pub const VAL_MAX: EmacsInt = (EMACS_INT_MAX >> (GCTYPEBITS - 1));
 pub const VALMASK: EmacsInt = [VAL_MAX, -(1 << GCTYPEBITS)][USE_LSB_TAG as usize];

--- a/rust_src/remacs-bindings/src/main.rs
+++ b/rust_src/remacs-bindings/src/main.rs
@@ -128,6 +128,7 @@ fn generate_globals(path: &str) {
     let mut out_file = File::create(out_path).expect("Failed to create definition file");
     let mut parse_state = ParseState::ReadingGlobals;
 
+    write!(out_file, "use crate::{{\n    lisp::LispObject,\n    definitions::*,\n    bindings::*,\n}};\n\n").expect("Write error!");
     write!(out_file, "#[allow(unused)]\n").expect("Write error!");
     write!(out_file, "#[repr(C)]\n").expect("Write error!");
     write!(out_file, "pub struct emacs_globals {{\n").expect("Write error!");
@@ -313,10 +314,11 @@ fn run_bindgen(path: &str) {
                 r"pub use self\s*::\s*gnutls_cipher_algorithm_t as gnutls_cipher_algorithm\s*;",
             );
             let munged = re.unwrap().replace_all(&source, "");
-            let file = File::create(out_path);
-            file.unwrap()
-                .write_all(munged.into_owned().as_bytes())
-                .unwrap();
+            let mut file = File::create(out_path).unwrap();
+
+            write!(file, "use crate::{{\n    lisp::LispObject,\n    globals::*,\n}};\n\nuse libc::timespec;\ntype Lisp_Object = LispObject;\n").expect("Write error!");
+            file.write(munged.into_owned().as_bytes()).expect("Write error!");
+            // file.unwrap();
         }
     }
 }

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -674,9 +674,9 @@ $(RUSTFLAGS_FILE) : FORCE
 
 HEADERS=$(wildcard $(srcdir)/*.h)
 
-DEFINITIONS_FILE=$(rust_srcdir)/generated/definitions.rs
-BINDINGS_FILE=$(rust_srcdir)/generated/bindings.rs
-GLOBALS_FILE=$(rust_srcdir)/generated/globals.rs
+DEFINITIONS_FILE=$(rust_srcdir)/crates/lisp/src/definitions.rs
+BINDINGS_FILE=$(rust_srcdir)/crates/lisp/src/bindings.rs
+GLOBALS_FILE=$(rust_srcdir)/crates/lisp/src/globals.rs
 # macuvs.h has a rule to regenerate it which depends on emacs being
 # built. That creates a circular dependency which we can break by not
 # depending on it as this is not a file that changes under normal


### PR DESCRIPTION
Seems like rust analyzer cannot handle exported symbols from `include!`