### PR TITLE
Return early from CursorMoved if top_frame is none

### DIFF
--- a/rust_src/src/webrender_backend/term.rs
+++ b/rust_src/src/webrender_backend/term.rs
@@ -555,13 +555,13 @@ extern "C" fn read_input_event(terminal: *mut terminal, hold_quit: *mut input_ev
         } => {
             dpyinfo.input_processor.cursor_move(position);
 
-            unsafe {
-                note_mouse_highlight(
-                    top_frame.as_frame().unwrap().as_mut(),
-                    position.x as i32,
-                    position.y as i32,
-                )
-            };
+            if top_frame.as_frame().is_none() {
+                return;
+            }
+
+            let mut frame: LispFrameRef = top_frame.into();
+
+            unsafe { note_mouse_highlight(frame.as_mut(), position.x as i32, position.y as i32) };
         }
 
         Event::WindowEvent {


### PR DESCRIPTION
Running with `--with-webrender`, emacs would panic on startup with an "unwrap on a none value" message referencing the `CursorMoved` event handler. I'm not well-versed in Rust but it seems like there was an assumption in the code that `top_frame.as_frame()` would be something like `Option<LispFrameRef>` but it was in fact `None`. It looks like some of the other event handlers handled this issue in the way that I've now done so in this commit. This change has now allowed me to build a working emacs with webrender, which is quite cool.