### PR TITLE
ci: auto generate release deb package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Create Release Asset
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+  push:
+    tags:
+      'v*'
+
+jobs:
+  build:
+    name: Create Release Asset
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Install minimal nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - name: Set outputs
+        id: vars
+        run: |
+          tag=${GITHUB_REF#refs/tags/*}
+          sha=$(git rev-parse --short HEAD)
+          version=$([[ $tag == v* ]] && echo ${tag:1} || echo 0.0.$sha)
+          prerelease=$([[ $tag == v* ]] && echo false || echo true)
+          echo "tag=$tag" >> $GITHUB_ENV
+          echo "sha=$sha" >> $GITHUB_ENV
+          echo "version=$version" >> $GITHUB_ENV
+          echo "prerelease=$prerelease" >> $GITHUB_ENV
+      - name: Build project # This would actually build your project, using zip for an example artifact
+        run: |
+          ./build_emacs_ng.sh ${{ env.version }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ env.version }}
+          release_name: emacs-ng_${{ env.version }}
+          draft: false
+          prerelease: ${{ env.prerelease }}
+      - name: Upload Release Asset
+        id: upload_release_asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./emacs-ng_${{ env.version }}-1_amd64.deb
+          asset_name: emacs-ng_${{ env.version }}-1_amd64.deb
+          asset_content_type: application/vnd.debian.binary-package

--- a/build_emacs_ng.sh
+++ b/build_emacs_ng.sh
@@ -1,0 +1,24 @@
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
+sudo apt install -y autoconf make checkinstall texinfo libxpm-dev libjpeg-dev \
+     libgtk-3-dev libgif-dev libtiff-dev libpng-dev libgnutls28-dev libncurses5-dev \
+     libsystemd-dev libjansson-dev libharfbuzz-dev libgccjit-10-dev gcc-10 g++-10
+sudo apt update
+sudo apt -y upgrade
+
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+
+./autogen.sh
+./configure CFLAGS="-Wl,-rpath,shared -Wl,--disable-new-dtags" \
+            --with-json --with-modules --with-harfbuzz --with-compress-install \
+            --with-threads --with-included-regex --with-zlib --with-cairo --with-libsystemd \
+             --with-nativecomp \
+            --without-rsvg --without-sound --without-imagemagick --without-makeinfo \
+            --without-gpm --without-dbus --without-pop --without-toolkit-scroll-bars \
+            --without-mailutils --without-gsettings \
+            --with-all
+sudo make NATIVE_FULL_AOT=1 PATH=$PATH:$HOME/.cargo/bin -j$(nproc)
+sudo checkinstall -y -D --pkgname=emacs-ng --pkgversion="$1" \
+     --requires="libgif-dev,libjansson-dev,libharfbuzz-dev,libgtk-3-dev,libncurses5-dev,libgccjit-10-dev" \
+     --pkggroup=emacs --gzman=yes --install=no\
+     make install-strip


### PR DESCRIPTION
Allow to automatically create deb release package based on weekly prerelease and tag based stable release.
The uploaded deb package is named with following convention:
- Weekly prerelease: `emacs-ng_0.0.<sha>-1_amd64.deb`
- Stable release for tag `vx.y`: `emacs-ng_x.y-1_amd64.deb`

Todo:
- Don't create new weekly release if there's no new commit?
- Support more package format?