### PR TITLE
Doc link fix, remove trailing space

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ The answer here is a loud NO. The maintainers love elisp and we will never remov
 
 ## How should I use JS/TS as an existing package maintainer?
 
-If you have a large elisp package, our guidance is not that you should rewrite your entire package in JS/TS. Instead, we encourage package maintainers to explore using JS/TS's Async I/O and Threading capabilities to improve performance their hot code paths on emacs-ng. Using `(featurep 'emacs-ng)`, you can include an import statement for a JS/TS package that defun's functions for you to use. Our [Getting Started Guide](https://github.com/emacs-ng/emacs-ng/blob/master/getting-started.md) is a good place to start.
+If you have a large elisp package, our guidance is not that you should rewrite your entire package in JS/TS. Instead, we encourage package maintainers to explore using JS/TS's Async I/O and Threading capabilities to improve performance their hot code paths on emacs-ng. Using `(featurep 'emacs-ng)`, you can include an import statement for a JS/TS package that defun's functions for you to use. Our [Getting Started Guide](https://github.com/emacs-ng/emacs-ng/blob/master/docs/getting-started.md) is a good place to start.
 
 ## How does adding JS/TS affect your ability to merge future emacs improvements?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,7 @@ If these typescript examples are taking a long time to evaluate, it's likely due
 (js-initialize :no-check t)
 ```
 
-This code will cleanup your current JS environment and re-initialize it with TypeScript type checking disabled. If you do not care about the type checking that TypeScript offers, or your computer struggles with the cost of compiling, you can add `(js-initialize :no-check t)` to your init.el. 
+This code will cleanup your current JS environment and re-initialize it with TypeScript type checking disabled. If you do not care about the type checking that TypeScript offers, or your computer struggles with the cost of compiling, you can add `(js-initialize :no-check t)` to your init.el.
 
 Let's stop printing to the minibuffer, and instead start pushing our results into buffers. Let's start by something simple: make a network call and dump the results into a buffer.
 

--- a/docs/main-features.md
+++ b/docs/main-features.md
@@ -3,7 +3,7 @@
 ## Javascript
 This code is a strictly additive layer, it changes no elisp functionality, and should be able to merge upstream patches cleanly. JS tests can be run by building the editor and executing `cd test && ../src/emacs --batch -l js/bootstrap.el`.
 
-To learn more about JavaScript and TypeScript, it is recommended you check out [Getting Started](https://github.com/emacs-ng/emacs-ng/blob/master/getting-started.md), [Using Deno](https://github.com/emacs-ng/emacs-ng/blob/master/using-deno.md), and [Advanced Features](https://github.com/emacs-ng/emacs-ng/blob/master/adv-features.md)
+To learn more about JavaScript and TypeScript, it is recommended you check out [Getting Started](https://github.com/emacs-ng/emacs-ng/blob/master/docs/getting-started.md), [Using Deno](https://github.com/emacs-ng/emacs-ng/blob/master/docs/using-deno.md), and [Advanced Features](https://github.com/emacs-ng/emacs-ng/blob/master/docs/adv-features.md)
 
 ### Using Async I/O
 
@@ -30,7 +30,7 @@ This example assumes you have a json file named `test.json` in your current dire
 
 ### WebWorkers and Parallel Scripting
 
-We also support WebWorkers, meaning that you can run javascript in separate threads. Note that WebWorkers cannot interact with the lisp VM, however they can use Deno for async I/O. See [Advanced Features](https://github.com/emacs-ng/emacs-ng/blob/master/adv-features.md)
+We also support WebWorkers, meaning that you can run javascript in separate threads. Note that WebWorkers cannot interact with the lisp VM, however they can use Deno for async I/O. See [Advanced Features](https://github.com/emacs-ng/emacs-ng/blob/master/docs/adv-features.md)
 
 Web Assembly allows you to perform things normally handled by native libraries with easy distribution. Want to manipulate sqlite3? Use the [deno sqlite wasm package](https://deno.land/x/sqlite@v2.3.2/mod.ts)
 
@@ -60,5 +60,3 @@ $ ./configure --with-webrender
 ```
 
 If you get "Couldn't find any available vsync extension" runtime panic, enabling 3D acceleration will fixes it.
-
-


### PR DESCRIPTION
I looked at the documentation in `docs` and the link was broken.
Corrected, and removed trailing spaces.