### PR TITLE
Enable dynamic modules to directly read current buffer's text

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6117,9 +6117,11 @@ esac
 if test "$HAVE_LIBVTERM" = "yes"; then
    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"libvterm\", "
 fi
-
 if test "${with_javascript}" = "yes"; then
   CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"javascript\", "
+fi
+if test "${HAVE_MODULES}" = "yes"; then
+  CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"ng-module\", "
 fi
 AC_SUBST(CARGO_DEFAULT_FEATURES)
 AC_CONFIG_FILES([rust_src/Cargo.toml])

--- a/docs/ng-module.md
+++ b/docs/ng-module.md
@@ -1,0 +1,94 @@
+# Dynamic Modules
+
+Emacs-ng is always built with dynamic modules support enabled, and is *fully compatible* with dynamic modules written for "vanilla" Emacs.
+
+On top of the existing `emacs-module.h` interface, Emacs-ng provides additional extensions that allow dynamic modules to access *more of Emacs's internals*. Dynamic modules can be written to take advantage of these extra functionalities when they are available, while at the same time being *fully compatible* with vanilla Emacs.
+
+The additional extensions are exposed as a registry of named native functions that can be looked up at run time. These native functions are called *ng-module functions*:
+
+```emacs-lisp
+ELISP> (ng-module-function-address "ng_module_access_current_buffer_contents")
+#<user-ptr ptr=0x10e31120d finalizer=0x0>
+ELISP> (ng-module-function-address "non_existing_or_removed_function")
+nil
+```
+
+Unlike normal module functions from `emacs_env`,  these ng-module functions have *globally stable addresses*. Therefore, the lookup can (and should) be done once, at module load time, inside `emacs_module_init`. Also note that, even though the lookup function `ng-module-function-address` is available to Lisp code, it is intended to be used by dynamic modules' native code. (Lisp code cannot meaningfully use the returned address, anyway.)
+
+Once an ng-module function is added, its signature will not change. If a similar ng-module function with improved functionalities is added, it will be given a different name. However, a ng-module function **can be removed**.
+
+## Direct access to buffer text
+
+To access a buffer's text, a "vanilla" dynamic module has to call a buffer-to-string function, like `buffer-substring`, then call `emacs_env->copy_string_contents` (resulting in a `memcpy`). The temporary Lisp string is typically discarded right away. This is a potential performance bottleneck in hot code paths, like [emacs-tree-sitter](https://github.com/ubolonton/emacs-tree-sitter)'s parsing/querying.
+
+A dynamic module can instead use the ng-module function `ng_module_access_current_buffer_contents` to directly read a buffer's text, without copying, or creating a Lisp string. It returns the pointers to (and the sizes of) the 2 contiguous byte segments before and after the buffer's gap.
+
+The caller **must not write** through the returned pointers, and must ensure that the data is **read before it is invalidated**. Some operations that may invalidate the data are: buffer modifications, garbage collection (which can be triggered by uses of `emacs_env`), arena compaction (which can be triggered by `malloc` when Emacs is built with `REL_ALLOC`).
+
+Below is an example of how to use this function in a dynamic module written in Rust:
+
+```rust
+use std::mem::{self, MaybeUninit};
+use once_cell::sync::OnceCell;
+use emacs::Env;
+
+type AccessBufferContents = unsafe fn(*mut *const u8, *mut isize, *mut *const u8, *mut isize);
+
+#[allow(non_upper_case_globals)]
+pub static ng_module_access_current_buffer_contents: OnceCell<AccessBufferContents> = OnceCell::new();
+
+#[emacs::module]
+fn init(env: &Env) -> Result<()> {
+    let get_addr = env.call("symbol-function", [env.intern("ng-module-function-address")?])?;
+    // Got the registry.
+    if get_addr.is_not_nil() {
+        // Look up the ng-module function.
+        match get_addr.call(("ng_module_access_current_buffer_contents",))?.into_rust::<Option<Value>>()? {
+            Some(addr) => {
+                // Got the pointer, "cast" it to the signature promised by ng-module.
+                buffer::ng_module_access_current_buffer_contents.set(
+                    unsafe { mem::transmute(addr.get_user_ptr()?) }
+                ).unwrap();
+            }
+            None => (),
+        }
+    }
+    Ok(())
+}
+
+pub unsafe fn current_buffer_contents(_: &Env) -> (&[u8], &[u8]) {
+    let mut before_gap = MaybeUninit::uninit();
+    let mut after_gap = MaybeUninit::uninit();
+    let mut before_gap_size: isize = 0;
+    let mut after_gap_size: isize = 0;
+    let get_slices = ng_module_access_current_buffer_contents.get().unwrap();
+    get_slices(
+        before_gap.as_mut_ptr(),
+        &mut before_gap_size,
+        after_gap.as_mut_ptr(),
+        &mut after_gap_size,
+    );
+    let before_gap_size = before_gap_size;
+    let after_gap_size = after_gap_size;
+    (
+        if before_gap_size > 0 {
+            std::slice::from_raw_parts(
+                before_gap.assume_init(),
+                before_gap_size as usize,
+            )
+        } else {
+            &[]
+        },
+        if after_gap_size > 0 {
+            std::slice::from_raw_parts(
+                after_gap.assume_init(),
+                after_gap_size as usize,
+            )
+        } else {
+            &[]
+        },
+    )
+}
+```
+
+A future version of [emacs-module-rs](https://github.com/ubolonton/emacs-module-rs/) may provide a more convenient wrapper for this function.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
     - Advanced features: adv-features.md
   - Getting started: getting-started.md
   - Using Deno: using-deno.md
+  - Dynamic modules: ng-module.md
   - FAQ: faq.md
 
 theme:

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -96,5 +96,7 @@ window-system-webrender = ["font-kit", "webrender", "glutin", "gleam", "app_unit
 strict = []
 # Use JavaScript and Deno
 javascript = ["deno", "deno_core", "deno_runtime", "tokio", "rusty_v8", "tokio-rustls"]
+# Build with dynamic modules support's extensions.
+ng-module = []
 # Enable glyphs debugging code.
 glyph-debug = []

--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -393,6 +393,9 @@ fn build_ignored_paths() -> Vec<&'static str> {
     #[cfg(not(feature = "window-system-webrender"))]
     ignored_paths.push("wrterm.rs");
 
+    #[cfg(not(feature = "ng-module"))]
+    ignored_paths.push("ng_module.rs");
+
     ignored_paths
 }
 

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -71,6 +71,7 @@ mod git;
 mod javascript;
 mod javascript_stubs;
 mod ng_async;
+#[cfg(feature = "ng-module")]
 mod ng_module;
 mod parsing;
 #[cfg(feature = "javascript")]

--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -71,6 +71,7 @@ mod git;
 mod javascript;
 mod javascript_stubs;
 mod ng_async;
+mod ng_module;
 mod parsing;
 #[cfg(feature = "javascript")]
 mod subcommands;

--- a/rust_src/src/ng_module.rs
+++ b/rust_src/src/ng_module.rs
@@ -1,0 +1,76 @@
+//! Emacs-ng's extensions to the dynamic module interface, `emacs-module.h`.
+//!
+//! Since we want to be ABI-compatible with dynamic modules written for vanilla Emacs, we don't add
+//! more functions to `emacs_env`. Instead, we provide a registry of named native functions that
+//! dynamic modules can look up at run time. We call these `ng-module functions`. Unlike normal
+//! module functions, ng-module functions have globally stable addresses, which should be looked up
+//! once, at module load time (in `emacs_module_init`). Their names should start with `ng_module_`.
+//!
+//! To ensure ABI compatibility, once an ng-module function is added, its signature must not be
+//! changed. If a new function is a slight modification of an existing function, consider using a
+//! suffix (descriptive, or numeric) to distinguish them. It is ok to remove an ng-module function.
+//! However, its name must not be reused.
+//!
+//! To make the ABI easy to consume, primitive data types are preferred over structs. If a struct
+//! is used, it must be marked `#[repr(C)]`, and its layout must not be changed.
+
+use lisp::{
+    lisp::LispObject,
+    multibyte::LispStringRef,
+    remacs_sys::{buffer_text, current_thread, make_user_ptr, Qnil, BYTE_POS_ADDR},
+};
+use lisp_macros::lisp_fn;
+
+/// Return the address of the ng-module function with the given NAME.
+/// Return nil if Emacs-ng does not provide such a module function.
+///
+/// For the full list of available functions, see the file 'ng_module.rs'.
+///
+/// This function is intended to be used by dynamic modules at module
+/// load time (in `emacs_module_init'), not normal Lisp code.
+#[lisp_fn]
+pub fn ng_module_function_address(name: LispStringRef) -> LispObject {
+    macro_rules! expose {
+        ($($name:ident)*) => {
+            match name.to_utf8().as_ref() {
+                $(stringify!($name) => unsafe { make_user_ptr(None, $name as *mut libc::c_void) },)*
+                _ => Qnil,
+            }
+        }
+    }
+    expose! {
+        ng_module_access_current_buffer_contents
+    }
+}
+
+/// Returns the pointers to, and the sizes of the 2 contiguous segments inside the current buffer.
+///
+/// This can be used for direct read-only access to the current buffer's text.
+///
+/// # Safety
+///
+/// Various operations can invalidate the returned values: buffer modifications, garbage collection,
+/// arena compaction...
+unsafe extern "C" fn ng_module_access_current_buffer_contents(
+    before_gap_ptr: *mut *const u8,
+    before_gap_size: *mut isize,
+    after_gap_ptr: *mut *const u8,
+    after_gap_size: *mut isize,
+) {
+    let buffer = (*current_thread).m_current_buffer;
+    let text = (*buffer).text;
+    let buffer_text {
+        beg,
+        gpt_byte,
+        gap_size,
+        z_byte,
+        ..
+    } = *text;
+    let beg_byte = 1;
+    *before_gap_ptr = BYTE_POS_ADDR(beg_byte);
+    *before_gap_size = gpt_byte - beg_byte;
+    *after_gap_ptr = beg.add((*before_gap_size + gap_size) as usize);
+    *after_gap_size = z_byte - gpt_byte;
+}
+
+include!(concat!(env!("OUT_DIR"), "/ng_module_exports.rs"));


### PR DESCRIPTION
Since we want to be ABI-compatible with dynamic modules written for vanilla Emacs, we don't add more functions to `emacs_env`.

Instead, we provide a registry of named native functions that can be looked up at run time. We call these `ng-module functions`. Unlike normal module functions, they have globally stable addresses, which should be looked up once, at module load time (in `emacs_module_init`).

I made a [quick prototype](https://github.com/ubolonton/emacs-tree-sitter/commit/381cf5cdd300bf2df347f53f163d0d9d59635c36) that shows how to use this in `emacs-tree-sitter`. Some quick-n-dirty tests show up to 2x speedups.