### PR TITLE
ci: make release pipeline more efficient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Install minimal nightly
-        uses: actions-rs/toolchain@v1
+      - name: Get latest release
+        id: cur_release
+        uses: pozetroninc/github-action-get-latest-release@master
         with:
-          profile: minimal
-          toolchain: nightly
+          repository: emacs-ng/emacs-ng
+          excludes: draft
       - name: Set outputs
         id: vars
         run: |
@@ -29,6 +30,7 @@ jobs:
           sha=$(git rev-parse --short HEAD)
           version=$([[ $tag == v* ]] && echo ${tag:1} || echo 0.0.$sha)
           prerelease=$([[ $tag == v* ]] && echo false || echo true)
+          [[ v$version == ${{ steps.cur_release.outputs.release }} ]] && exit 1
           echo "tag=$tag" >> $GITHUB_ENV
           echo "sha=$sha" >> $GITHUB_ENV
           echo "version=$version" >> $GITHUB_ENV
@@ -36,19 +38,15 @@ jobs:
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
           ./build_emacs_ng.sh ${{ env.version }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Do Release
+        id: do_release
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: v${{ env.version }}
-          release_name: emacs-ng_${{ env.version }}
+          tag: v${{ env.version }}
+          name: emacs-ng_${{ env.version }}
           draft: false
           prerelease: ${{ env.prerelease }}
-      - name: Upload Release Asset
-        id: upload_release_asset
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./emacs-ng_${{ env.version }}-1_amd64.deb
-          asset_name: emacs-ng_${{ env.version }}-1_amd64.deb
-          asset_content_type: application/vnd.debian.binary-package
+          artifactErrorsFailBuild: true
+          artifacts: ./emacs-ng_${{ env.version }}-1_amd64.deb
+          artifactContentType: application/vnd.debian.binary-package
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/build_emacs_ng.sh
+++ b/build_emacs_ng.sh
@@ -1,17 +1,18 @@
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
+sudo apt update
 sudo apt install -y autoconf make checkinstall texinfo libxpm-dev libjpeg-dev \
      libgtk-3-dev libgif-dev libtiff-dev libpng-dev libgnutls28-dev libncurses5-dev \
-     libsystemd-dev libjansson-dev libharfbuzz-dev libgccjit-10-dev gcc-10 g++-10 libxt-dev \
+     libsystemd-dev libjansson-dev libharfbuzz-dev libgccjit-9-dev gcc-9 g++-9 libxt-dev \
      libclang-10-dev
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-sudo apt update
-sudo apt -y upgrade
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --profile minimal --default-toolchain nightly
 
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
 
 ./autogen.sh
+
 ./configure CFLAGS="-Wl,-rpath,shared -Wl,--disable-new-dtags" \
             --with-json --with-modules --with-harfbuzz --with-compress-install \
             --with-threads --with-included-regex --with-zlib --with-cairo --with-libsystemd \
@@ -20,8 +21,8 @@ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
             --without-gpm --without-dbus --without-pop --without-toolkit-scroll-bars \
             --without-mailutils --without-gsettings \
             --with-all
-sudo make NATIVE_FULL_AOT=1 PATH=$PATH:$HOME/.cargo/bin -j$(nproc)
+sudo make NATIVE_FULL_AOT=1 PATH=$PATH:$HOME/.cargo/bin -j$(($(nproc) * 2))
 sudo checkinstall -y -D --pkgname=emacs-ng --pkgversion="$1" \
-     --requires="libgif-dev,libjansson-dev,libharfbuzz-dev,libgtk-3-dev,libncurses5-dev,libgccjit-10-dev" \
+     --requires="libjpeg-dev,libxpm-dev,libgtk-3-dev,libgif-dev,libtiff-dev,libpng-dev,libjansson-dev,libharfbuzz-dev,libgtk-3-dev,libncurses5-dev,libgccjit-9-dev" \
      --pkggroup=emacs --gzman=yes --install=no\
      make install-strip


### PR DESCRIPTION
Make the release pipeline more efficient by:
- Don't attempt to build a new release if the code has not changed from the last release
- Don't install `rust` in release pipeline anymore since it will be installed by the script later.
- Fix bug in build script that makes the `configure` not effective, making `native-compilation` Emacs not being built.
- Switch from `libgccjit-10` -> `libgccjit-9` for better compatible with older distro and also include more libs as deps