### PR TITLE
ci: use github.repository instead of hardcode in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         id: cur_release
         uses: pozetroninc/github-action-get-latest-release@master
         with:
-          repository: emacs-ng/emacs-ng
+          repository: ${{ github.repository }}
           excludes: draft
       - name: Set outputs
         id: vars


### PR DESCRIPTION
Minor fix to use current repository in release CI instead of hardcoding