### PR TITLE
Add instructions to compile emacs-ng docs

### DIFF
--- a/generate-docs.sh
+++ b/generate-docs.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# emacs-ng documentation is generated using the Python package mkdocs
+# you can install it with `pip install mkdocs`
+# and then run `mkdocs build`, it will load `mkdocs.yml`
+# generated HTML documentation will be found in `./site`
+
+# or using a Docker container:
+# - create a Github token with one permission: read-packages
+# - export it an environment variable (`export GITHUB_TOKEN=xxx`)
+# - run this script
+
+GITHUB_ACTOR=YOUR_GITHUB_USERNAME
+GITHUB_TOKEN=${GITHUB_TOKEN}
+
+cp -rf images README.md docs
+docker login docker.pkg.github.com --username $GITHUB_ACTOR --password $GITHUB_TOKEN
+docker run --rm -v ${PWD}:/docs docker.pkg.github.com/emacs-ng/docs-image/docs-image -- build


### PR DESCRIPTION
Hi @brotzeit 

this is a small script + info on how to compile locally the [documentation for emacs-ng](https://emacs-ng.github.io/emacs-ng). I find it useful to iterate when I'm editing the documentation before submitting a patch.

It's just the content of the [Github action](https://github.com/emacs-ng/emacs-ng/blob/45403b76ba72b9273d9022faa9f12d4ab0c03927/.github/workflows/docs.yml#L15-L19) dumped in a file for easier reach.

Would that help? Or else, where should this be? 

thanks for checking this out!