### PR TITLE
flake.nix: remacsSrc hashsum fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
     "emacsNg-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1619505640,
-        "narHash": "sha256-YRJBdC2bOTvaUzN2SbXxvb7usv4YwN6ya9w1tidnyKs=",
+        "lastModified": 1619808667,
+        "narHash": "sha256-nedzULHHb1L8aNJCXEEaLoBPDWDDvH1Z7aIrCQ72/UQ=",
         "owner": "emacs-ng",
         "repo": "emacs-ng",
-        "rev": "a93e3e4ba9254ebe3147dacc695f5cc42b975a09",
+        "rev": "f1b64666f1a53f37850bdfc37154ad5cb4a4242f",
         "type": "github"
       },
       "original": {
@@ -143,11 +143,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1619490314,
-        "narHash": "sha256-PDta6J/ZewJFkPy1yNplzsn53vsqaNt/z3NYz/C4W1I=",
+        "lastModified": 1619835986,
+        "narHash": "sha256-RZ6opJgAJhcW6jou50D+V36BHu3WUc2uh4C42vx4kio=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4062bc4c899019c2c7b11d26ae142837cbf0d0dc",
+        "rev": "4f2051c76032e86338219f477e5ac9e522dd362a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
                     sed -e 's/@CARGO_.*@//' Cargo.toml.in > Cargo.toml
                   '' + doVersionedUpdate;
                   name = "remacsSrc";
-                  sha256 = "sha256-1ELtwJeAyIO1I35Its/pwsA+/d7lHDighSFPFbIBXIQ=";
+                  sha256 = "sha256-Tn1sbMSIjy+VTId5lrlw8eeBFgIiAtQoSv6c+VDvmfI=";
                   inherit installPhase;
                 };
 


### PR DESCRIPTION
to prevent:
```bash
error: hash mismatch in fixed-output derivation '/nix/store/502ysqvil5rnqaasmvkrysw0h5ywzk3m-remacsSrc-vendor.tar.gz.drv':
         specified: sha256-1ELtwJeAyIO1I35Its/pwsA+/d7lHDighSFPFbIBXIQ=
            got:    sha256-Tn1sbMSIjy+VTId5lrlw8eeBFgIiAtQoSv6c+VDvmfI=
```