### PR TITLE
Add Dockerfile to build for Debian

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+docker-emacs-ng
+docker
+docs
+generate-docs.sh
+nix
+default.nix
+.git

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,55 @@
+FROM debian:bullseye-slim
+
+# using local cloned repo
+WORKDIR /src
+COPY . /src
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Needed for add-apt-repository, et al.
+RUN apt update && apt upgrade -y \
+        && apt install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        software-properties-common \
+        git
+
+# deps
+RUN apt install -y clang autoconf make checkinstall texinfo \
+    librsvg2-dev libxpm-dev libjpeg-dev libgtk-3-dev libgif-dev libtiff-dev libjpeg62-turbo-dev libpng-dev \
+    libgnutls28-dev libncurses5-dev libsystemd-dev libjansson-dev libjansson4 libharfbuzz-dev libxt-dev \
+    libgccjit-10-dev gcc-10 g++-10
+
+# Cleanup apt cache to reclaim some space
+RUN apt clean && rm -rf /var/lib/apt/lists/*
+
+# Download Rust nightly
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+     sh -s -- -y --default-host x86_64-unknown-linux-gnu --default-toolchain $( cat rust-toolchain )
+RUN . $HOME/.cargo/env && rustup component add rustfmt
+
+# configure emacs-ng compilation
+# TODO: add webrender
+RUN . $HOME/.cargo/env && ./autogen.sh && \
+    ./configure PATH=$PATH:$HOME/.cargo/bin CFLAGS="-Wl,-rpath,shared -Wl,--disable-new-dtags" \
+    --with-json --with-modules --with-harfbuzz --with-compress-install \
+    --with-threads --with-included-regex --with-zlib --with-cairo --with-libsystemd \
+    --with-rsvg --with-native-compilation \
+    --without-sound --without-imagemagick --without-makeinfo --without-gpm --without-dbus \
+    --without-pop --without-toolkit-scroll-bars --without-mailutils --without-gsettings \
+    --with-all
+
+# compile
+RUN . $HOME/.cargo/env && \
+    make PATH=$PATH:$HOME/.cargo/bin -j$(nproc) && \
+    make install-strip
+
+# make .deb
+RUN checkinstall -y -D --pkgname=emacs-ng --pkgversion="0.1" \
+  --requires="libjansson4,libncurses5,libgccjit0,librsvg2-2,libxpm4,libgif7,libtiff5,libjpeg62-turbo,libpng16-16,libgtk-3-0,libharfbuzz0b" \
+  --pkggroup=emacs --gzman=yes --install=no \
+  make install-strip
+
+CMD ["/bin/bash"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,39 @@
+# Build emacs-ng using a Docker container
+
+To ease the job of building emacs-ng, we are preparing Docker images
+to allow a fully containerized build without installing any build dependencies.
+
+Bulding this will create a Docker image of about ~9 gb and will take
+quite some time (~45 minutes, depending on your workstation specs). Once the
+build is completed you can extract the artifact out of the container
+and install it.
+
+Usage example of the Dockerfile for building for Debian GNU/Linux:
+
+Clone the emacs-ng repository and build the image locally:
+``` sh
+$ git clone --depth=1 https://github.com/emacs-ng/emacs-ng.git
+$ cd emacs-ng
+$ docker build -t emacs-ng:builder -f docker/Dockerfile.debian .
+```
+
+At the end you should read this output:
+``` sh
+**********************************************************************
+
+ Done. The new package has been saved to
+
+ /src/emacs-ng_0.1-1_amd64.deb
+ You can install it in your system anytime using:
+
+      dpkg -i emacs-ng_0.1-1_amd64.deb
+
+**********************************************************************
+```
+
+Copy the .deb out of the container, then destroy the container:
+``` sh
+$ container_id=$( docker run -d --name delete-me emacs-ng:builder )
+$ docker cp $container_id:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
+$ docker rm delete-me
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,3 +1,1 @@
-## Install emacs-ng from binary distributions
-
-Our CI builds releases [packages for Ubuntu 20](https://github.com/emacs-ng/emacs-ng/releases), you can find instruction on how to build with Docker [for other Linux distributions](https://github.com/emacs-ng/emacs-ng/tree/master/docker): contributions are welcome!
+Our CI currently builds [binary releases for Ubuntu](https://github.com/emacs-ng/emacs-ng/releases). Expect more to come: contributions are welcome!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Overview: README.md
     - Setup:
       - Build from source: building.md
+      - Build with Docker: docker.md
       - Release .deb package: release.md
       - Nix Build / Develop: nix-develop.md
   - Features:


### PR DESCRIPTION
This will add a Dockefile to build a .deb for Debian.

It works but I'll iterate a bit more on this to see if I can slim this down a bit

(also suggestions and reviews welcome)

Ref: #235 