### PR TITLE
Ignore Cargo.lock

### DIFF
--- a/rust_src/.gitignore
+++ b/rust_src/.gitignore
@@ -1,3 +1,5 @@
+Cargo.lock
+
 target
 generated/
 


### PR DESCRIPTION
Since this file changes with different configure options, it seems to make sense to ignore this file.