### PR TITLE
Add define_derived_mode 

### DIFF
--- a/rust_src/crates/js/src/prelim.js
+++ b/rust_src/crates/js/src/prelim.js
@@ -419,6 +419,9 @@
   const define_minor_mode = (...args) =>
     evalForm(lisp.q.define_minor_mode, ...args);
 
+  const define_derived_mode = (...args) =>
+    evalForm(lisp.q.define_derived_mode, ...args);
+
   const specialForms = {
     make: makeFuncs,
     q: symbolsCached(),
@@ -435,6 +438,7 @@
     defvar,
     define_key,
     define_minor_mode,
+    define_derived_mode,
   };
 
   global.lisp = new Proxy({}, {


### PR DESCRIPTION
:wave:   This PR exposes `define-derived-mode` as special forms like `define-minor-mode` in order to create a major mode derived