### PR TITLE
build_emacs_ng: fix build scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Create Release Asset
 on:
   schedule:
     - cron: "0 0 * * 0" # weekly
+  workflow_dispatch:
   push:
     tags:
       'v*'
@@ -14,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get latest release
+        continue-on-error: true
         id: cur_release
         uses: pozetroninc/github-action-get-latest-release@master
         with:
@@ -25,16 +27,21 @@ jobs:
           tag=${GITHUB_REF#refs/tags/*}
           sha=$(git rev-parse --short HEAD)
           version=$([[ $tag == v* ]] && echo ${tag:1} || echo 0.0.$sha)
+          cur_ver=$([[ ${{ steps.cur_release.outcome }} == failure ]] && echo v0 || echo ${{ steps.cur_release.outputs.release }})
+          [[ v$version == $cur_ver ]] && exit 1
           prerelease=$([[ $tag == v* ]] && echo false || echo true)
           rust_cache=${{ hashFiles('**/rust-toolchain', '**/Cargo.lock') }}
-          [[ v$version == ${{ steps.cur_release.outputs.release }} ]] && exit 1
           echo "version=$version" >> $GITHUB_ENV
+          echo "arch=$(dpkg-architecture -q DEB_BUILD_ARCH)" >> $GITHUB_ENV
           echo "prerelease=$prerelease" >> $GITHUB_ENV
           echo "rust_cache=$rust_cache" >> $GITHUB_ENV
+          echo "rust_toolchain=$(cat rust-toolchain)" >> $GITHUB_ENV
     outputs:
       version: ${{ env.version }}
+      arch: ${{ env.arch }}
       prerelease: ${{ env.prerelease }}
       rust_cache: ${{ env.rust_cache }}
+      rust_toolchain: ${{ env.rust_toolchain }}
 
   build:
     needs: prepare_env
@@ -49,6 +56,11 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v2
+      - name: rust setup
+        id: rust-setup
+        run: |
+          rustup install $(cat rust-toolchain)
+          rustup component add rustfmt-preview
       - name: Cache rust
         uses: actions/cache@v2
         with:
@@ -56,9 +68,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ./rust_src/target
-          key: ${{ runner.os }}-cargo-${{ needs.prepare_env.outputs.rust_cache }}
-          restore-keys:
-            ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-${{ matrix.build }}-cargo-${{ needs.prepare_env.outputs.rust_cache }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.build }}-cargo
       - name: Build project
         if: ${{ matrix.build == 'general' }}
         run: |
@@ -66,7 +78,7 @@ jobs:
           bin_version=$version
           echo "version=$version" >> $GITHUB_ENV
           echo "bin_version=$bin_version" >> $GITHUB_ENV
-          ./build_emacs_ng.sh $version
+          ./build_emacs_ng.sh $bin_version
       - name: Build project with webrender
         if: ${{ matrix.build == 'webrender' }}
         run: |
@@ -74,7 +86,7 @@ jobs:
           bin_version=$version.webrender
           echo "version=$version" >> $GITHUB_ENV
           echo "bin_version=$bin_version" >> $GITHUB_ENV
-          ./build_emacs_ng.sh $version.webrender --with-webrender
+          ./build_emacs_ng.sh $bin_version --with-webrender
       - name: Reduce cache
         continue-on-error: true
         run: |
@@ -103,7 +115,7 @@ jobs:
           draft: false
           prerelease: ${{ needs.prepare_env.outputs.prerelease }}
           artifactErrorsFailBuild: true
-          artifacts: ./emacs-ng_${{ env.bin_version }}-1_amd64.deb
+          artifacts: ./emacs-ng_${{ env.bin_version }}_${{ needs.prepare_env.outputs.arch }}.deb
           artifactContentType: application/vnd.debian.binary-package
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Do upload to release
@@ -112,6 +124,6 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
-          asset_path: ./emacs-ng_${{ env.bin_version }}-1_amd64.deb
-          asset_name: emacs-ng_${{ env.bin_version }}-1_amd64.deb
+          asset_path: ./emacs-ng_${{ env.bin_version }}_${{ needs.prepare_env.outputs.arch }}.deb
+          asset_name: emacs-ng_${{ env.bin_version }}_${{ needs.prepare_env.outputs.arch }}.deb
           asset_content_type: application/vnd.debian.binary-package

--- a/build_emacs_ng.sh
+++ b/build_emacs_ng.sh
@@ -8,26 +8,32 @@ render_libs="librsvg2-dev libxpm-dev libjpeg-dev libtiff-dev libpng-dev libgif-d
 render_deps=",librsvg2-2,libxpm4,libjpeg9,libtiff5,libgif7,libpng16-16,libgtk-3-0,libharfbuzz0b"
 
 if [[ ${@:2} == *--with-webrender* ]]; then
-    echo "in"
     render_libs="${render_libs} libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev"
     render_deps="${render_deps},libxcb1,libxcb-render0,libxcb-shape0,libxcb-xfixes0"
 fi
 
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
 sudo apt update
-sudo apt install -y autoconf make checkinstall texinfo $render_libs libgnutls28-dev \
+sudo apt install -y dpkg-dev autoconf make texinfo $render_libs libgnutls28-dev \
      libncurses5-dev libsystemd-dev libjansson-dev libgccjit-9-dev gcc-9 g++-9 libxt-dev \
      libclang-10-dev curl
-
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --profile minimal --default-toolchain $(cat rust-toolchain)
 
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
 
 ./autogen.sh
 
+arch=$(dpkg-architecture -q DEB_BUILD_ARCH)
+pkg_name=emacs-ng_$1_$arch
+deb_dir=$(pwd)/$pkg_name
+mkdir -p $deb_dir/usr/local/
+
+echo arch=$arch
+echo deb_dir=$deb_dir
+echo pkg_name=$pkg_name
+
 ./configure CFLAGS="-Wl,-rpath,shared -Wl,--disable-new-dtags" \
+            --prefix=/usr/local/ \
             --with-json --with-modules --with-harfbuzz --with-compress-install \
             --with-threads --with-included-regex --with-zlib --with-cairo --with-libsystemd \
             --with-rsvg --with-native-compilation ${@:2}\
@@ -35,8 +41,21 @@ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
             --without-pop --without-toolkit-scroll-bars --without-mailutils --without-gsettings \
             --with-all
 
-sudo make NATIVE_FULL_AOT=1 PATH=$PATH:$HOME/.cargo/bin -j$(($(nproc) * 2))
-sudo checkinstall -y -D --pkgname=emacs-ng --pkgversion="$1" \
-     --requires="libjansson4,libncurses5,libgccjit0${render_deps}" \
-     --pkggroup=emacs --gzman=yes --install=no \
-     make install-strip
+make -j$(($(nproc) * 2)) NATIVE_FULL_AOT=1
+# NOTE: use `checkinstall` will make `make install` hangs.
+# See https://github.com/emacs-ng/emacs-ng/issues/364
+make install-strip DESTDIR=$deb_dir
+
+# create control file
+mkdir -p $deb_dir/DEBIAN
+
+cat > $deb_dir/DEBIAN/control << EOF
+Package: emacs-ng
+Version: $1
+Architecture: $arch
+Maintainer: https://emacs-ng.github.io/emacs-ng/
+Description: A new approach to Emacs - Including TypeScript, Threading, Async I/O, and WebRender
+Depends: libjansson4,libncurses5,libgccjit0${render_deps}
+EOF
+
+dpkg-deb --build -z9 --root-owner-group $deb_dir


### PR DESCRIPTION
Fix build script to not use obsoleted `checkinstall` (which hangs recently) and switch to `dpkg-deb` instead to create deb file