### PR TITLE
webrender: simplify font creation.

### DIFF
--- a/rust_src/crates/webrender/src/font.rs
+++ b/rust_src/crates/webrender/src/font.rs
@@ -351,10 +351,6 @@ extern "C" fn open_font(frame: *mut frame, font_entity: LispObject, pixel_size: 
             .as_font_mut() as *mut WRFont,
     );
 
-    // Create font key in webrender.
-    let font_key = output.add_font(font);
-    wr_font.font_instance_key = output.add_font_instance(font_key, pixel_size as i32);
-
     let (font_bytes, face_index) = FONT_DB
         .db
         .with_face_data(font.id, |font_data, face_index| {
@@ -362,6 +358,10 @@ extern "C" fn open_font(frame: *mut frame, font_entity: LispObject, pixel_size: 
             (font_bytes, face_index)
         })
         .unwrap();
+
+    // Create font key in webrender.
+    let font_key = output.add_font(font_bytes.clone(), face_index);
+    wr_font.font_instance_key = output.add_font_instance(font_key, pixel_size as i32);
 
     wr_font.font_bytes = ManuallyDrop::new(font_bytes.clone());
 

--- a/rust_src/crates/webrender/src/output.rs
+++ b/rust_src/crates/webrender/src/output.rs
@@ -1,6 +1,5 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-use fontdb::{FaceInfo, Source};
 use gleam::gl::{self, Gl};
 use glutin::{
     self,
@@ -352,24 +351,12 @@ impl Output {
         font_instance_key
     }
 
-    pub fn add_font(&mut self, font_handle: &FaceInfo) -> FontKey {
+    pub fn add_font(&mut self, font_bytes: Rc<Vec<u8>>, font_index: u32) -> FontKey {
         let mut txn = Transaction::new();
 
         let font_key = self.render_api.generate_font_key();
 
-        let font_index = font_handle.index;
-        match font_handle.source.as_ref() {
-            Source::File(path) => {
-                let font = NativeFontHandle {
-                    path: path.clone().into_os_string().into(),
-                    index: font_index,
-                };
-                txn.add_native_font(font_key, font);
-            }
-            Source::Binary(bytes) => {
-                txn.add_raw_font(font_key, bytes.to_vec(), font_index);
-            }
-        }
+        txn.add_raw_font(font_key, font_bytes.to_vec(), font_index);
 
         self.render_api.send_transaction(self.document_id, txn);
 


### PR DESCRIPTION
Make macOS porting easier for font related code.