### PR TITLE
webrender: multiple frame

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,7 +154,7 @@
                       cp -r ${pathDir} crates
                       sed -i 's|../crates/lisp_util|./crates/lisp_util|' Cargo.toml
                     '' + doVersionedUpdate;
-                  sha256 = "sha256-w49ROzIvgdQpSrWHomtg6eEmssZFmgLsJ/optFSuaEY=";
+                  sha256 = "sha256-XvGLnzh5GKiiVeWPiIxrnV2eDr6LvRe5UvnIGlkQk6w=";
                   inherit installPhase;
                 };
 

--- a/rust_src/crates/webrender/src/display_info.rs
+++ b/rust_src/crates/webrender/src/display_info.rs
@@ -1,3 +1,4 @@
+use glutin::window::WindowId;
 use libc;
 use std::{collections::HashMap, ptr};
 
@@ -13,7 +14,7 @@ pub struct DisplayInfoInner {
     pub terminal: TerminalRef,
     pub focus_frame: LispFrameRef,
 
-    pub output: OutputRef,
+    pub outputs: HashMap<WindowId, OutputRef>,
 
     pub input_processor: InputProcessor,
 
@@ -27,7 +28,7 @@ impl Default for DisplayInfoInner {
         DisplayInfoInner {
             terminal: TerminalRef::new(ptr::null_mut()),
             focus_frame: LispFrameRef::new(ptr::null_mut()),
-            output: OutputRef::new(ptr::null_mut()),
+            outputs: HashMap::new(),
             input_processor: InputProcessor::new(),
             scratch_cursor_gc: Box::new(Emacs_GC {
                 foreground: 0,

--- a/rust_src/crates/webrender/src/event_loop.rs
+++ b/rust_src/crates/webrender/src/event_loop.rs
@@ -6,6 +6,7 @@ use glutin::platform::unix::EventLoopWindowTargetExtUnix;
 use glutin::{
     event::{Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopProxy},
+    monitor::MonitorHandle,
     platform::run_return::EventLoopExtRunReturn,
     window::{WindowBuilder, WindowId},
     ContextBuilder, ContextCurrentState, CreationError, NotCurrent, WindowedContext,
@@ -92,6 +93,16 @@ impl WrEventLoop {
         {
             return Platform::Windows;
         }
+    }
+
+    pub fn get_available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        self.el.available_monitors()
+    }
+
+    pub fn get_primary_monitor(&self) -> MonitorHandle {
+        self.el
+            .primary_monitor()
+            .unwrap_or_else(|| -> MonitorHandle { self.get_available_monitors().next().unwrap() })
     }
 }
 

--- a/rust_src/crates/webrender/src/frame.rs
+++ b/rust_src/crates/webrender/src/frame.rs
@@ -36,14 +36,20 @@ pub fn create_frame(
     frame.set_output_method(output_method::output_wr);
 
     let mut event_loop = EVENT_LOOP.lock().unwrap();
-    let mut output = Box::new(Output::build(&mut event_loop));
+    let mut output = Box::new(Output::build(&mut event_loop, frame));
+
+    let window_id = output.get_window().id();
+
     output.set_display_info(dpyinfo);
 
     // Remeber to destory the Output object when frame destoried.
     let output = Box::into_raw(output);
     frame.output_data.wr = output as *mut wr_output;
 
-    dpyinfo.get_inner().output = frame.wr_output();
+    dpyinfo
+        .get_inner()
+        .outputs
+        .insert(window_id, frame.wr_output());
 
     frame
 }

--- a/rust_src/crates/webrender/src/output.rs
+++ b/rust_src/crates/webrender/src/output.rs
@@ -527,6 +527,10 @@ impl OutputRef {
     pub fn as_mut(&mut self) -> *mut wr_output {
         self.0 as *mut wr_output
     }
+
+    pub fn as_rust_ptr(&mut self) -> *mut Output {
+        self.0 as *mut Output
+    }
 }
 
 impl Deref for OutputRef {

--- a/rust_src/crates/webrender/src/term.rs
+++ b/rust_src/crates/webrender/src/term.rs
@@ -558,7 +558,13 @@ extern "C" fn read_input_event(terminal: *mut terminal, hold_quit: *mut input_ev
 
         match e {
             Event::WindowEvent { window_id, event } => {
-                let output = dpyinfo.outputs.get_mut(&window_id).unwrap();
+                let output = dpyinfo.outputs.get_mut(&window_id);
+
+                if output.is_none() {
+                    continue;
+                }
+
+                let output = output.unwrap();
 
                 let frame: LispObject = output.get_frame().into();
 
@@ -818,6 +824,19 @@ extern "C" fn free_pixmap(f: *mut Lisp_Frame, pixmap: Emacs_Pixmap) {
     frame.wr_output().delete_image(image_key);
 }
 
+extern "C" fn delete_frame(f: *mut Lisp_Frame) {
+    let frame: LispFrameRef = f.into();
+    let mut output = frame.wr_output();
+
+    let display_info = output.display_info();
+    let window_id = output.get_window().id();
+
+    display_info.get_inner().outputs.remove(&window_id);
+
+    // Take back output ownership and destroy it
+    let _ = unsafe { Box::from_raw(output.as_rust_ptr()) };
+}
+
 fn wr_create_terminal(mut dpyinfo: DisplayInfoRef) -> TerminalRef {
     let terminal_ptr = unsafe {
         create_terminal(
@@ -849,6 +868,7 @@ fn wr_create_terminal(mut dpyinfo: DisplayInfoRef) -> TerminalRef {
     terminal.mouse_position_hook = Some(mouse_position);
     terminal.update_end_hook = Some(update_end);
     terminal.free_pixmap = Some(free_pixmap);
+    terminal.delete_frame_hook = Some(delete_frame);
 
     terminal
 }

--- a/rust_src/crates/webrender/src/wrterm.rs
+++ b/rust_src/crates/webrender/src/wrterm.rs
@@ -8,6 +8,7 @@ use glutin::{event::VirtualKeyCode, monitor::MonitorHandle};
 
 use lisp_macros::lisp_fn;
 
+use crate::event_loop::EVENT_LOOP;
 use crate::frame::frame_edges;
 use crate::frame::LispFrameExt;
 use crate::{
@@ -619,13 +620,11 @@ pub fn webrender_monitor_to_emacs_monitor(m: MonitorHandle) -> (MonitorInfo, Opt
 ///
 /// Internal use only, use `display-monitor-attributes-list' instead.
 #[lisp_fn(min = "0")]
-pub fn x_display_monitor_attributes_list(terminal: LispObject) -> LispObject {
-    let dpyinfo = check_x_display_info(terminal);
+pub fn x_display_monitor_attributes_list(_terminal: LispObject) -> LispObject {
+    let event_loop = EVENT_LOOP.lock().unwrap();
 
-    let output = dpyinfo.get_inner().output;
-
-    let monitors: Vec<_> = output.get_available_monitors().collect();
-    let primary_monitor = output.get_primary_monitor();
+    let monitors: Vec<_> = event_loop.get_available_monitors().collect();
+    let primary_monitor = event_loop.get_primary_monitor();
 
     let mut primary_monitor_index = 0;
 
@@ -693,12 +692,10 @@ pub fn x_display_monitor_attributes_list(terminal: LispObject) -> LispObject {
 /// physical monitors associated with TERMINAL.  To get information for
 /// each physical monitor, use `display-monitor-attributes-list'.
 #[lisp_fn(min = "0")]
-pub fn x_display_pixel_width(terminal: LispObject) -> i32 {
-    let dpyinfo = check_x_display_info(terminal);
+pub fn x_display_pixel_width(_terminal: LispObject) -> i32 {
+    let event_loop = EVENT_LOOP.lock().unwrap();
 
-    let output = dpyinfo.get_inner().output;
-
-    let primary_monitor = output.get_primary_monitor();
+    let primary_monitor = event_loop.get_primary_monitor();
 
     let dpi_factor = primary_monitor.scale_factor();
 
@@ -718,12 +715,10 @@ pub fn x_display_pixel_width(terminal: LispObject) -> i32 {
 /// physical monitors associated with TERMINAL.  To get information for
 /// each physical monitor, use `display-monitor-attributes-list'.
 #[lisp_fn(min = "0")]
-pub fn x_display_pixel_height(terminal: LispObject) -> i32 {
-    let dpyinfo = check_x_display_info(terminal);
+pub fn x_display_pixel_height(_terminal: LispObject) -> i32 {
+    let event_loop = EVENT_LOOP.lock().unwrap();
 
-    let output = dpyinfo.get_inner().output;
-
-    let primary_monitor = output.get_primary_monitor();
+    let primary_monitor = event_loop.get_primary_monitor();
 
     let dpi_factor = primary_monitor.scale_factor();
 


### PR DESCRIPTION
closes https://github.com/emacs-ng/emacs-ng/issues/344

An known issue: After closing the second window, the wayland-client library throw a error after random time. I think it related to winit's wayland library.
It works well on X11.
