### PR TITLE
webrender: use thread_select when running without window system

### DIFF
--- a/rust_src/crates/webrender/src/output.rs
+++ b/rust_src/crates/webrender/src/output.rs
@@ -72,8 +72,8 @@ impl Output {
 
         #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
         let window_builder = {
-            let invocation_name_ref: LispStringRef = unsafe { globals.Vinvocation_name.into() };
-            let invocation_name = invocation_name_ref.to_utf8();
+            let invocation_name: LispStringRef = unsafe { globals.Vinvocation_name.into() };
+            let invocation_name = invocation_name.to_utf8();
             window_builder.with_app_id(invocation_name)
         };
 

--- a/rust_src/crates/webrender/src/wrterm.rs
+++ b/rust_src/crates/webrender/src/wrterm.rs
@@ -24,10 +24,11 @@ use emacs::{
     bindings::globals,
     bindings::resource_types::{RES_TYPE_NUMBER, RES_TYPE_STRING, RES_TYPE_SYMBOL},
     bindings::{
-        block_input, gui_display_get_arg, hashtest_eql, image as Emacs_Image, list3i, make_fixnum,
-        make_hash_table, make_monitor_attribute_list, register_font_driver, unblock_input, Display,
-        Emacs_Pixmap, Emacs_Rectangle, Fcons, Fcopy_alist, Fmake_vector, Fprovide, MonitorInfo,
-        Vframe_list, Window, DEFAULT_REHASH_SIZE, DEFAULT_REHASH_THRESHOLD,
+        block_input, build_string, gui_display_get_arg, hashtest_eql, image as Emacs_Image, list3i,
+        make_fixnum, make_hash_table, make_monitor_attribute_list, register_font_driver,
+        unblock_input, Display, Emacs_Pixmap, Emacs_Rectangle, Fcons, Fcopy_alist, Fmake_vector,
+        Fprovide, MonitorInfo, Vframe_list, Window, CHECK_STRING, DEFAULT_REHASH_SIZE,
+        DEFAULT_REHASH_THRESHOLD,
     },
     definitions::EmacsInt,
     frame::{all_frames, window_frame_live_or_selected, LispFrameRef},
@@ -423,6 +424,14 @@ pub fn x_open_connection(
     _xrm_string: LispObject,
     _must_succeed: LispObject,
 ) -> LispObject {
+    let display = if display.is_nil() {
+        unsafe { build_string("".as_ptr() as *const ::libc::c_char) }
+    } else {
+        display
+    };
+
+    unsafe { CHECK_STRING(display) };
+
     let mut display_info = wr_term_init(display);
 
     // Put this display on the chain.

--- a/rust_src/ng-bindgen/src/main.rs
+++ b/rust_src/ng-bindgen/src/main.rs
@@ -275,6 +275,9 @@ fn run_bindgen(path: &str) {
                 // .blacklist_item("Lisp_.*fwd")
                 // these are defined in remacs_lib
                 .blacklist_item("timespec")
+                .blacklist_item("fd_set")
+                .blacklist_item("pselect")
+                .blacklist_item("sigset_t")
                 .blacklist_item("timex")
                 .blacklist_item("clock_adjtime")
                 // by default we want C enums to be converted into a Rust module with constants in it
@@ -315,7 +318,7 @@ fn run_bindgen(path: &str) {
             );
             let munged = re.unwrap().replace_all(&source, "");
             let mut file = File::create(out_path).unwrap();
-            write!(file, "use crate::{{\n    globals::emacs_globals,\n    sys::Lisp_Object,\n}};\n\nuse libc::timespec;\n").expect("Write error!");
+            write!(file, "use crate::{{\n    globals::emacs_globals,\n    sys::Lisp_Object,\n}};\n\nuse libc::{{timespec, fd_set, sigset_t}};\n").expect("Write error!");
             file.write_all(munged.into_owned().as_bytes()).unwrap();
         }
     }


### PR DESCRIPTION
Fixed two minor webrender issues:

- Terminal Emacs (`-nw`) not working on macOS
- Need manually pass `DISPLAY=${hostname}` to open a GUI frame on macOS
Copied the logic from [PGTK](https://github.com/masm11/emacs/blob/pgtk/src/pgtkfns.c#L2127-L2130)