### PR TITLE
also require use-package during bootstrap

### DIFF
--- a/lisp/emacs-lisp/emacs-ng.el
+++ b/lisp/emacs-lisp/emacs-ng.el
@@ -48,6 +48,7 @@ call (ng-bootstrap-straight) in your init-file."
   (interactive)
 
   (require 'straight)
+  (require 'use-package)
 
   (setq ng--straight-bootstrapped t)
 


### PR DESCRIPTION
@declanqian it seems it's necessary to also require use-package. I get `nil` when evaluating `(featurep 'use-package)`.