### PR TITLE
introduce wiki section for built-in elisp packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,49 +112,14 @@ tools to make Emacs a smoother and faster experience without having to
 install additional tools to launch as background processes or worry
 about shared library versions.
 
-### Built-in Emacs Lisp packages
-emacs-ng distributed with more built-in Emacs Lisp packages than upstream GNU Emacs.
-For now, we have [straight.el](https://github.com/raxod502/straight.el/tree/develop)
-`08b0ecf` and [use-package](https://github.com/jwiegley/use-package) `a7422fb`
-included.
+### Package management
 
-#### `straight.el`
-We are kind of using `straight.el` as an alternative of `package.el`, providing
-`ng-straight-bootstrap-at-startup`, `ng-bootstrap-straight` (as equipment of
-`package-enable-at-startup` and `package-initialize`).
+use-package and straight are really great so we decided to make them
+built-in packages. But since we don't want to break configs, this is
+an [optional feature](https://emacs-ng.github.io/emacs-ng/package-management).
 
-##### Usage
-Emacs NG automatically bootstraps `straight.el` at
-startup if `ng-straight-bootstrap-at-startup` is set to `t`, the default value is `nil`
+Just put this line into your `~./emacs.d/early-init.el`:
 
-You must configure the built-in `straight.el` in the early init file,
-as the variable `ng-straight-bootstrap-at-startup` is read before
-loading the regular init file. There are some variables you may be interested in
-(some of them must be set **before** the bootstrap process, if they might affect how
-`straight.el` itself is loaded). You can find the details from [this section](https://github.com/raxod502/straight.el/tree/develop#getting-started)
-of the `straight.el`'s documentation.
-
-To be compatible with upstream Emacs, you can place the following in your init-file:
-
+```elisp
+(setq ng-straight-bootstrap-at-startup t)
 ```
-(unless (fboundp 'ng-bootstrap-straight)
-  (defvar bootstrap-version)
-  (let ((bootstrap-file
-         (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
-        (bootstrap-version 5))
-    (unless (file-exists-p bootstrap-file)
-      (with-current-buffer
-          (url-retrieve-synchronously
-           "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
-           'silent 'inhibit-cookies)
-        (goto-char (point-max))
-        (eval-print-last-sexp)))
-    (load bootstrap-file nil 'nomessage)))
-```
-
-For more detailed guide, please refer [straight.el's READMD.md](https://github.com/raxod502/straight.el/blob/develop/README.md).
-
-#### `use-package`
-There are also [discussions/efforts](https://github.com/jwiegley/use-package/issues/282) to
-include `use-package` into upstream. Until then, we temporally included it with
-`emacs-ng`.

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -1,0 +1,58 @@
+# Built-in Emacs Lisp packages
+
+emacs-ng distributed with more built-in Emacs Lisp packages than
+upstream GNU Emacs.  For now, we have
+[straight.el](https://github.com/raxod502/straight.el/tree/develop)
+`08b0ecf` and [use-package](https://github.com/jwiegley/use-package)
+`a7422fb` included.
+
+## `straight.el`
+
+We are kind of using `straight.el` as an alternative of `package.el`,
+providing `ng-straight-bootstrap-at-startup`, `ng-bootstrap-straight`
+(as equipment of `package-enable-at-startup` and
+`package-initialize`).
+
+### Usage
+
+Emacs NG automatically bootstraps `straight.el` at startup if
+`ng-straight-bootstrap-at-startup` is set to `t`, the default value is
+`nil`
+
+You must configure the built-in `straight.el` in the early init file,
+as the variable `ng-straight-bootstrap-at-startup` is read before
+loading the regular init file. There are some variables you may be
+interested in (some of them must be set **before** the bootstrap
+process, if they might affect how `straight.el` itself is loaded). You
+can find the details from [this
+section](https://github.com/raxod502/straight.el/tree/develop#getting-started)
+of the `straight.el`'s documentation.
+
+To be compatible with upstream Emacs, you can place the following in
+your init-file:
+
+```
+(unless (fboundp 'ng-bootstrap-straight)
+  (defvar bootstrap-version)
+  (let ((bootstrap-file
+         (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+        (bootstrap-version 5))
+    (unless (file-exists-p bootstrap-file)
+      (with-current-buffer
+          (url-retrieve-synchronously
+           "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
+           'silent 'inhibit-cookies)
+        (goto-char (point-max))
+        (eval-print-last-sexp)))
+    (load bootstrap-file nil 'nomessage)))
+```
+
+For more detailed guide, please refer [straight.el's
+READMD.md](https://github.com/raxod502/straight.el/blob/develop/README.md).
+
+## `use-package`
+
+There are also
+[discussions/efforts](https://github.com/jwiegley/use-package/issues/282)
+to include `use-package` into upstream. Until then, we temporally
+included it with `emacs-ng`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Build with Docker: build/docker.md
       - Release .deb package: build/release.md
       - Nix Build / Develop: build/nix-develop.md
+    - Package management: package-management.md
   - Deno/Javascript:
     - Using Deno: js/using-deno.md
     - Getting started: js/getting-started.md


### PR DESCRIPTION
@declanqian maybe it's better to keep the readme short and only give an overview of the available features and have more detailed docs in the wiki. What do you think ?