### PR TITLE
webrender: integrate wr capture infra

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -513,6 +513,9 @@ OPTION_DEFAULT_OFF([webrender],
   [enable use of webrender(written in Rust) as GUI backend on
 multiple platforms(Linux, Windows and MacOS) (experimental)])
 
+OPTION_DEFAULT_OFF([webrender-capture],
+  [enable use of Webrender capture infrastructure])
+
 ## Based on Deno 1.9.1
 ## Update the above when upgrading Deno
 OPTION_DEFAULT_ON([javascript],
@@ -6196,6 +6199,7 @@ fi || AC_MSG_ERROR(['src/epaths.h' could not be made.])
 
 
 CARGO_DEFAULT_FEATURES=""
+WEBRENDER_DEFAULT_FEATURES="\"webrender\""
 if test "$HAVE_LIBXML2" = "yes"; then
     CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"use-xml2\", "
 fi
@@ -6214,6 +6218,9 @@ case "$window_system" in
     ;;
     webrender)
         CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"window-system-webrender\", "
+        if test "${with_webrender_capture}" = "yes"; then
+            WEBRENDER_DEFAULT_FEATURES="${WEBRENDER_DEFAULT_FEATURES}, \"webrender/capture\""
+        fi
     ;;
 esac
 if test "$HAVE_LIBGIT" = "yes"; then
@@ -6227,6 +6234,7 @@ if test "${HAVE_MODULES}" = "yes"; then
   CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"ng-module\", "
 fi
 AC_SUBST(CARGO_DEFAULT_FEATURES)
+AC_SUBST(WEBRENDER_DEFAULT_FEATURES)
 AC_CONFIG_FILES([rust_src/Cargo.toml])
 
 dnl NB we have to cheat and use the ac_... version because abs_top_srcdir

--- a/lisp/wr-fns.el
+++ b/lisp/wr-fns.el
@@ -1,0 +1,176 @@
+;;; wr-fns.el --- Webrender specific functions       -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021  Declan Qian
+
+;; Author: Declan Qian <>
+;; Keywords: lisp
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'transient)
+
+(defconst WR-CAPTURE-BITS '(("SCENE" . #x1)
+                            ("FRAME" . #x2)
+                            ("TILE_CACHE" . #x4)
+                            ("EXTERNAL_RESOURCES" . #x8)
+                            ("ALL" . #xf)))
+
+(defvar wr-capture--in-progress nil)
+
+(defun wr-capture--in-progress-p ()
+  wr-capture--in-progress)
+
+(defun wr-capture--bits-completion-table (completions)
+  (lambda (string pred action)
+    (if (eq action 'metadata)
+        `(metadata (display-sort-function . ,#'identity))
+      (complete-with-action action completions string pred))))
+
+(defun wr-capture--bits-format (value &optional key)
+  (format "%s(#x%x)" (or key (car (rassoc value WR-CAPTURE-BITS))) value))
+
+(defun wr-capture--bits-reader (prompt initial-input _history)
+  "Read a Bit flags."
+  (let* ((initial-input (and transient-read-with-initial-input
+                             (wr-capture--bits-format initial-input)))
+         (sorted-bits (sort
+                       (copy-sequence WR-CAPTURE-BITS)
+                       (lambda (a b)
+                         (> (cdr a) (cdr b)))))
+         (choices (mapcar
+                   (lambda (element)
+                     (let ((key (car element))
+                           (value (cdr element)))
+                       (wr-capture--bits-format value key)))
+                   sorted-bits))
+         (choice
+          (completing-read
+           prompt (wr-capture--bits-completion-table choices)
+           nil t initial-input))
+         (key (car (split-string choice "(")))
+         (value (cdr (assoc key WR-CAPTURE-BITS))))
+    value))
+
+(defun wr-capture--generate-capture-path (path)
+  "Increment the extension until we find a fresh path"
+  (let* ((path (expand-file-name "wr-capture" path))
+         (count (string-to-number (or (file-name-extension path) "0"))))
+    (progn
+      (while (file-exists-p (concat path "." (number-to-string count)))
+        (setq count (+ count 1)))
+      (concat path "." (number-to-string count)))))
+
+(defun wr-capture--path-reader (prompt initial-input _history)
+  "`wr-capture--path-infix' transient infix reader."
+  (let* ((initial-input (and transient-read-with-initial-input
+                             (file-name-directory initial-input)))
+         (path (file-local-name
+                (expand-file-name
+                 (read-directory-name prompt initial-input))))
+         (path (wr-capture--generate-capture-path path)))
+    path))
+
+(defclass wr-capture--bits-infix (transient-infix) ()
+  "Bit flags for WR stages to store in a capture.")
+
+(defclass wr-capture--path-infix (transient-infix) ()
+  "wr capture path infix")
+
+(cl-defmethod transient-format-value ((obj wr-capture--bits-infix))
+  (with-slots (value) obj
+    (propertize (wr-capture--bits-format value)
+                'face 'transient-value)))
+
+(cl-defmethod transient-format-value ((obj wr-capture--path-infix))
+  (with-slots (value) obj
+    (propertize value
+                'face 'transient-value)))
+
+(defun wr-capture--bits-init-value (obj)
+  (let* ((hvalue (cadr (oref transient--prefix value)))
+         (value (if (and hvalue (numberp hvalue))
+                    hvalue
+                   #xf)))
+    (oset obj value value)))
+
+(defun wr-capture--path-init-value (obj)
+  (let* ((hvalue (car (oref transient--prefix value)))
+         (storage-path (if (and hvalue (stringp hvalue))
+                           (file-name-directory hvalue)
+                         default-directory))
+         (value (wr-capture--generate-capture-path storage-path)))
+    (oset obj value value)))
+
+(transient-define-infix  wr-capture.bits()
+  :description "Bit flags for WR stages to store in a capture."
+  :argument "bits"
+  :init-value #'wr-capture--bits-init-value
+  :always-read t
+  :reader #'wr-capture--bits-reader
+  :class 'wr-capture--bits-infix)
+
+(transient-define-infix  wr-capture.path()
+  :description "Save to directory: "
+  :argument "path"
+  :init-value #'wr-capture--path-init-value
+  :reader #'wr-capture--path-reader
+  :class 'wr-capture--path-infix
+  :always-read t)
+
+;;;###autoload (autoload 'wr-capture "wr-fns" nil t)
+(transient-define-prefix wr-capture ()
+  ;; Transient dispatcher for WebRender capture infrastructure commands
+  ["Arguments"
+   :if-not wr-capture--in-progress-p
+   ("--" wr-capture.path)
+   ("-b" wr-capture.bits)]
+  ["Actions"
+   :if-not wr-capture--in-progress-p
+   ("c" wr-capture-suffix)
+   ("s" wr-start-capture-sequence-suffix)]
+  ["Actions"
+   :if wr-capture--in-progress-p
+   ("S" wr-stop-capture-sequence-suffix)]
+  (interactive)
+  (unless (featurep 'wr-capture) (user-error "Webrender capture not available"))
+  (transient-setup 'wr-capture))
+
+(transient-define-suffix wr-capture-suffix ()
+  "Transient suffix to invoke `wr--capture'"
+  :description "Capture"
+  (interactive)
+  (apply #'wr-api-capture (transient-args transient-current-command)))
+
+(transient-define-suffix wr-start-capture-sequence-suffix ()
+  "Transient suffix to invoke `wr--start-capture-sequence'"
+  :description "Start capture sequence"
+  (interactive)
+  (apply #'wr-api-capture `(,@(transient-args transient-current-command) 't))
+  (setq wr-capture--in-progress t))
+
+(transient-define-suffix wr-stop-capture-sequence-suffix ()
+  "Transient suffix to invoke `wr--stop-capture-sequence'"
+  :description "Stop capture sequence"
+  (interactive)
+  (wr-api-stop-capture-sequence)
+  (setq wr-capture--in-progress nil))
+
+(provide 'wr-fns)
+;;; wr-fns.el ends here

--- a/rust_src/Cargo.lock
+++ b/rust_src/Cargo.lock
@@ -373,6 +373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d613611c914a7db07f28526941ce1e956d2f977b0c5e2014fbfa42230d420f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520d7de540904fd09b11c03a47d50a7ce4ff37d1aa763f454fa60d9088ef8356"
 dependencies = [
  "euclid",
+ "serde",
  "svg_fmt",
 ]
 
@@ -2053,6 +2065,23 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glsl"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b734216bb31c65d063e0264c8bbc688be12441bce2363a179c05a5f63c8fb1"
+dependencies = [
+ "nom 5.1.2",
+]
+
+[[package]]
+name = "glsl-to-cxx"
+version = "0.1.0"
+source = "git+https://github.com/servo/webrender.git?rev=ecbe93f7df289db2823c3c1fb748af5f3e4827ea#ecbe93f7df289db2823c3c1fb748af5f3e4827ea"
+dependencies = [
+ "glsl",
 ]
 
 [[package]]
@@ -3061,6 +3090,16 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -4262,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -4280,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -4415,6 +4454,9 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -4926,6 +4968,17 @@ dependencies = [
  "quote 1.0.8",
  "swc_macros_common",
  "syn 1.0.60",
+]
+
+[[package]]
+name = "swgl"
+version = "0.1.0"
+source = "git+https://github.com/servo/webrender.git?rev=ecbe93f7df289db2823c3c1fb748af5f3e4827ea#ecbe93f7df289db2823c3c1fb748af5f3e4827ea"
+dependencies = [
+ "cc",
+ "gleam",
+ "glsl-to-cxx",
+ "webrender_build",
 ]
 
 [[package]]
@@ -5731,6 +5784,7 @@ version = "0.1.0"
 dependencies = [
  "app_units",
  "bit-vec",
+ "cargo_toml",
  "copypasta",
  "emacs",
  "font-kit",
@@ -5778,8 +5832,11 @@ dependencies = [
  "objc",
  "plane-split",
  "rayon",
+ "ron",
+ "serde",
  "smallvec",
  "svg_fmt",
+ "swgl",
  "time",
  "tracy-rs",
  "webrender_api",
@@ -5816,6 +5873,7 @@ source = "git+https://github.com/servo/webrender.git?rev=ecbe93f7df289db2823c3c1
 dependencies = [
  "bitflags",
  "lazy_static",
+ "serde",
 ]
 
 [[package]]
@@ -6046,7 +6104,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
 dependencies = [
- "nom",
+ "nom 6.0.1",
 ]
 
 [[package]]

--- a/rust_src/Cargo.toml.in
+++ b/rust_src/Cargo.toml.in
@@ -70,7 +70,7 @@ window-system-w32 = []
 # Build with git2rs support
 libgit = ["git"]
 # Use the webrender window system
-window-system-webrender = ["webrender"]
+window-system-webrender = [@WEBRENDER_DEFAULT_FEATURES@]
 # Treat warnings as a build error on Travis.
 strict = []
 # Use JavaScript and Deno

--- a/rust_src/build.rs
+++ b/rust_src/build.rs
@@ -574,61 +574,6 @@ fn write_lisp_fns(
     Ok(())
 }
 
-#[cfg(feature = "window-system-webrender")]
-fn generate_rgb_list() {
-    let file = BufReader::new(File::open("../etc/rgb.txt").unwrap());
-    let color = file
-        .lines()
-        .filter_map(|line| line.ok())
-        .filter(|line| !line.trim().is_empty())
-        .filter(|line| !line.starts_with('#'))
-        .map(|line| {
-            let result = line
-                .trim()
-                .split("\t\t")
-                .map(|str| str.to_owned())
-                .collect::<Vec<String>>();
-
-            let color = result[0]
-                .split_whitespace()
-                .map(|str| str.to_owned())
-                .collect::<Vec<String>>();
-
-            let name = result[1].trim().to_lowercase();
-
-            let red = color[0].clone();
-            let green = color[1].clone();
-            let blue = color[2].clone();
-
-            (name, (red, green, blue))
-        });
-
-    let webrender_exports_path: PathBuf =
-        [&env_var("CARGO_MANIFEST_DIR"), "crates", "webrender", "out"]
-            .iter()
-            .collect();
-    let out_path = webrender_exports_path.join("colors.rs");
-
-    let color_function_body = format!(
-        "let mut color_map: HashMap<&'static str, (u8, u8, u8)> = HashMap::new(); {} color_map",
-        color
-            .map(|(name, (red, green, blue))| format!(
-                "color_map.insert(\"{}\", ({}, {}, {}));\n",
-                name, red, green, blue
-            ))
-            .collect::<Vec<String>>()
-            .concat()
-    );
-
-    let color_fun_source = format!(
-        "fn init_color() -> HashMap<&'static str, (u8, u8, u8)> {{ {} }}",
-        color_function_body
-    );
-
-    let mut file = File::create(out_path).unwrap();
-    file.write_all(color_fun_source.as_bytes()).unwrap();
-}
-
 fn main() {
     for varname in ["EMACS_CFLAGS", "SRC_HASH"].iter() {
         println!("cargo:rerun-if-env-changed={}", varname);
@@ -645,7 +590,4 @@ fn main() {
             }
         }
     }
-
-    #[cfg(feature = "window-system-webrender")]
-    generate_rgb_list();
 }

--- a/rust_src/crates/emacs/src/eval_macros.rs
+++ b/rust_src/crates/emacs/src/eval_macros.rs
@@ -65,6 +65,23 @@ macro_rules! error {
     }};
 }
 
+#[macro_export]
+macro_rules! message {
+    ($message:expr) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::xdisp::message1($message.to_string().as_ptr() as *const ::libc::c_char);
+        };
+    }};
+    ($message:expr, $($arg:expr),*) => {{
+        let message = format!($message, $($arg),*);
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::xdisp::message1(message.to_string().as_ptr() as *const ::libc::c_char);
+        };
+    }};
+}
+
 /// Macro that expands to nothing, but is used at build time to
 /// generate the starting symbol table. Equivalent to the DEFSYM
 /// macro. See also lib-src/make-docfile.c

--- a/rust_src/crates/emacs/src/lib.rs
+++ b/rust_src/crates/emacs/src/lib.rs
@@ -47,3 +47,4 @@ pub mod symbol;
 pub mod terminal;
 pub mod vector;
 pub mod window;
+pub mod xdisp;

--- a/rust_src/crates/emacs/src/xdisp.rs
+++ b/rust_src/crates/emacs/src/xdisp.rs
@@ -1,0 +1,12 @@
+//! Display generation from window structure and buffer text.
+
+/// Display a null-terminated echo area message M.  If M is 0, clear
+/// out any existing message, and let the mini-buffer text show through.
+
+/// The buffer M must continue to exist until after the echo area gets
+/// cleared or some other message gets displayed there.  Do not pass
+/// text that is stored in a Lisp string.  Do not pass text in a buffer
+/// that was alloca'd.
+pub fn message1(m: *const ::libc::c_char) {
+    unsafe { crate::bindings::message1(m) };
+}

--- a/rust_src/crates/webrender/Cargo.toml
+++ b/rust_src/crates/webrender/Cargo.toml
@@ -2,6 +2,7 @@
 name = "webrender"
 version = "0.1.0"
 edition = "2018"
+build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
@@ -26,7 +27,11 @@ once_cell = "1.8.0"
 tokio = { version = "1.10.0", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 futures = "0.3.16"
 
+[build-dependencies]
+cargo_toml = "0.10.1"
+
 [features]
 default = ["wayland", "x11"]
 x11 = ["copypasta/x11", "glutin/x11"]
 wayland = ["copypasta/wayland", "glutin/wayland"]
+capture=["webrender/capture", "webrender/serialize_program", "webrender/sw_compositor"]

--- a/rust_src/crates/webrender/build.rs
+++ b/rust_src/crates/webrender/build.rs
@@ -1,0 +1,101 @@
+// build.rs
+
+use cargo_toml::Dependency;
+use cargo_toml::Manifest;
+use std::fs::read;
+
+use std::env;
+use std::fs;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+
+const RGB_TXT_PATH: &str = "../../../etc/rgb.txt";
+const WEBRENDER_DEP_NAME: &str = "webrender";
+
+fn generate_webrender_revision() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let revision_file_path = Path::new(&out_dir).join("webrender_revision.rs");
+    let manifest = Manifest::from_slice(&read("Cargo.toml").unwrap()).unwrap();
+    let webrender_head_rev = {
+        if !manifest.dependencies.contains_key(WEBRENDER_DEP_NAME) {
+            "unknown"
+        } else {
+            let webrender_dep = &manifest.dependencies[WEBRENDER_DEP_NAME];
+            match webrender_dep {
+                Dependency::Detailed(detail) => detail.rev.as_ref().unwrap(),
+                Dependency::Simple(version) => version,
+            }
+        }
+    };
+
+    let mut revision_file = fs::File::create(&revision_file_path).unwrap();
+
+    write!(
+        &mut revision_file,
+        "{}",
+        format!(
+            "static WEBRENDER_HEAD_REV: Option<&'static str> = Some(\"{}\");",
+            webrender_head_rev
+        )
+    )
+    .unwrap();
+}
+
+fn generate_rgb_list() {
+    let file = BufReader::new(File::open(RGB_TXT_PATH).unwrap());
+    let color = file
+        .lines()
+        .filter_map(|line| line.ok())
+        .filter(|line| !line.trim().is_empty())
+        .filter(|line| !line.starts_with('#'))
+        .map(|line| {
+            let result = line
+                .trim()
+                .split("\t\t")
+                .map(|str| str.to_owned())
+                .collect::<Vec<String>>();
+
+            let color = result[0]
+                .split_whitespace()
+                .map(|str| str.to_owned())
+                .collect::<Vec<String>>();
+
+            let name = result[1].trim().to_lowercase();
+
+            let red = color[0].clone();
+            let green = color[1].clone();
+            let blue = color[2].clone();
+
+            (name, (red, green, blue))
+        });
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_path = Path::new(&out_dir).join("colors.rs");
+
+    let color_function_body = format!(
+        "let mut color_map: HashMap<&'static str, (u8, u8, u8)> = HashMap::new(); {} color_map",
+        color
+            .map(|(name, (red, green, blue))| format!(
+                "color_map.insert(\"{}\", ({}, {}, {}));\n",
+                name, red, green, blue
+            ))
+            .collect::<Vec<String>>()
+            .concat()
+    );
+
+    let color_fun_source = format!(
+        "fn init_color() -> HashMap<&'static str, (u8, u8, u8)> {{ {} }}",
+        color_function_body
+    );
+
+    let mut file = File::create(out_path).unwrap();
+    file.write_all(color_fun_source.as_bytes()).unwrap();
+}
+
+fn main() {
+    generate_rgb_list();
+    generate_webrender_revision();
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", RGB_TXT_PATH);
+}

--- a/rust_src/crates/webrender/src/color.rs
+++ b/rust_src/crates/webrender/src/color.rs
@@ -6,7 +6,7 @@ mod colors {
     use lazy_static::lazy_static;
     use std::collections::HashMap;
 
-    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/out/colors.rs"));
+    include!(concat!(env!("OUT_DIR"), "/colors.rs"));
 
     lazy_static! {
         pub static ref COLOR_MAP: HashMap<&'static str, (u8, u8, u8)> = init_color();


### PR DESCRIPTION
Wrote some rust/lisp, integrating [WebRender capture infrastructure](http://kvark.github.io/webrender/debug/ron/2018/01/23/wr-capture-infra.html) using
Transient interface. Didn't solve any existing problems here.
Only trying to get myself comfortable with the codebase.

Some notable changes:
- Added `webrender-head-rev` lisp var which reflects current webrender version in use.
- Add `message!` macro to send non-error text to Emacs echo area, as a complement to
`error!`.
- Moved webrender auto generated code to webrender/build.rs, aka `colors.rs`. Also newly
added `webrender_revision.rs`.

I think we should avoid generating code for other crates from `rust_src/build.rs`.
Also, did we misused [Cargo workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) for rust_src? Can't get my head around it.
```
rust_src/emacs-ng
rust_src/crates/**
```
Would make more sense to me.