### PR TITLE
Fix docs for building on docker

### DIFF
--- a/docs/build/docker.md
+++ b/docs/build/docker.md
@@ -35,5 +35,5 @@ Copy the .deb out of the container, then destroy the container:
 ``` sh
 $ docker run -d --name delete-me emacs-ng:builder
 $ docker cp delete-me:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
-$ docker rm delete-me
+$ docker stop delete-me && docker rm delete-me
 ```

--- a/docs/build/docker.md
+++ b/docs/build/docker.md
@@ -33,7 +33,7 @@ At the end you should read this output:
 
 Copy the .deb out of the container, then destroy the container:
 ``` sh
-$ docker run -d --rm --name delete-me emacs-ng:builder
+$ docker run -d --rm --name delete-me emacs-ng:builder bash -c 'tail -f /dev/null' --stop-signal SIGKILL
 $ docker cp delete-me:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
 $ docker stop delete-me
 ```

--- a/docs/build/docker.md
+++ b/docs/build/docker.md
@@ -34,6 +34,6 @@ At the end you should read this output:
 Copy the .deb out of the container, then destroy the container:
 ``` sh
 $ docker run -d --rm --name delete-me emacs-ng:builder bash -c 'tail -f /dev/null' --stop-signal SIGKILL
-$ docker cp delete-me:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
+$ docker cp delete-me:/src/emacs-ng_0.1-1_amd64.deb ~/tmp/
 $ docker stop delete-me
 ```

--- a/docs/build/docker.md
+++ b/docs/build/docker.md
@@ -33,7 +33,7 @@ At the end you should read this output:
 
 Copy the .deb out of the container, then destroy the container:
 ``` sh
-$ docker run -d --name delete-me emacs-ng:builder
+$ docker run -d --rm --name delete-me emacs-ng:builder
 $ docker cp delete-me:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
-$ docker stop delete-me && docker rm delete-me
+$ docker stop delete-me
 ```

--- a/docs/build/docker.md
+++ b/docs/build/docker.md
@@ -33,7 +33,7 @@ At the end you should read this output:
 
 Copy the .deb out of the container, then destroy the container:
 ``` sh
-$ container_id=$( docker run -d --name delete-me emacs-ng:builder )
-$ docker cp $container_id:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
+$ docker run -d --name delete-me emacs-ng:builder
+$ docker cp delete-me:/emacs-ng/emacs-ng_0.1-1_amd64.deb ~/tmp/
 $ docker rm delete-me
 ```


### PR DESCRIPTION
This PR is in my humble opinion. Please check and add comment.

I updated the document for building on docker ( https://emacs-ng.github.io/emacs-ng/build/docker/ ).
In my environment, the step copying `.deb` from container is not working.

The summary I updated is below.

- fix `.deb` file path
  - It is not in `/emacs-ng/` but in `/src/`.
- fix the container doesn't keep running
  - `docker run -d` doesn't keep running, I added the tail command.
- Remove container id
  - Container name ( `delete-me` ) can be used.
- add `--rm` argument and change `docker rm` to `docker stop`
  - without stopping container, the `docker rm` should be failed.