### PR TITLE
fix: wrong sha256 sum of emacsngLibDeps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,7 +133,7 @@
                   sed -i 's|../crates/lisp_util|./crates/lisp_util|' Cargo.toml
                 ''
                 + doVersionedUpdate;
-              sha256 = "sha256-LOzhuuucqDa1/wBqXPfPozHQL696JEmUgaTZ8y4yREA=";
+              sha256 = "sha256-+LZno11r6dD8At2/ZkKpWrX1L15PxodkaHNJBQaam4s=";
               inherit installPhase;
             };
 


### PR DESCRIPTION
I'm on aarch64-darwin building as x86_64-darwin

![2022-06-01 15 23 21](https://user-images.githubusercontent.com/6074754/171414798-3bd8011f-c4bd-465a-86ec-8f08f0de0674.png)
