### PR TITLE
Add native fontconfig support

### DIFF
--- a/Cargo.in
+++ b/Cargo.in
@@ -84,5 +84,6 @@ glyph-debug = []
 [patch.crates-io]
 winit = { git = "https://github.com/declantsien/winit", rev="d80de2ea150a36d078bd19b6c6ce1cc299304fc5" }
 
-[patch.crates-io.fontdb]
-git = "https://github.com/RazrFalcon/fontdb.git"
+[patch.crates-io.font-loader]
+git = "https://github.com/declantsien/rust-font-loader.git"
+rev = "0a53c767463e13346221ad23fa6dd50cd787cd72"

--- a/Cargo.in
+++ b/Cargo.in
@@ -26,6 +26,7 @@ edition = "2018"
 build = "rust_src/build.rs"
 
 [dependencies]
+libc = "0.2"
 remacs-lib = { version = "0.1.0", path = "rust_src/remacs-lib" }
 emacs = { version = "0.1.0", path = "rust_src/crates/emacs" }
 lisp-util = { version = "0.1.0", path = "rust_src/crates/lisp_util" }
@@ -37,6 +38,9 @@ ng_module = { version = "0.1.0", path = "rust_src/crates/ng_module", optional = 
 js = { version = "0.1.0", path = "rust_src/crates/js", optional = true }
 webrender = { version = "0.1.0", path = "rust_src/crates/webrender", optional = true }
 clippy = { version = "*", optional = true }
+log = "0.4.17"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["matchers", "regex", "once_cell", "tracing", "std", "thread_local", "env-filter"] }
 
 [build-dependencies]
 ng-bindgen = { path = "rust_src/ng-bindgen" }

--- a/rust_src/crates/webrender/Cargo.in
+++ b/rust_src/crates/webrender/Cargo.in
@@ -12,7 +12,6 @@ emacs = { path = "../emacs", features = ["window-system-webrender"] }
 lisp-macros = { path = "../lisp_macros" }
 lisp-util = {  path = "../lisp_util" }
 colors = {  path = "../../../etc/colors" }
-env_logger = "0.9.3"
 log = "0.4.17"
 libc = "0.2.95"
 lazy_static = "1.4"
@@ -28,6 +27,10 @@ futures = "0.3.25"
 winit = "0.27.5"
 fontdb = "0.12"
 nix = "0.26"
+tracing = "0.1"
+errno = "0.2"
+polling = "2.5"
+easy-parallel = "3.2"
 
 [dependencies.webrender]
 git = "https://github.com/servo/webrender.git"

--- a/rust_src/crates/webrender/Cargo.in
+++ b/rust_src/crates/webrender/Cargo.in
@@ -49,12 +49,15 @@ rev = "682fc7f787432de7b289e4caf4d8e248f85268c9"
 [build-dependencies]
 ng-bindgen = { path = "../../ng-bindgen" }
 
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+font-loader = "0.11"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.2"
 
 [features]
 default = ["wayland", @WEBRENDER_DEFAULT_FEATURES@]
-x11 = ["copypasta/x11", "surfman/sm-x11", "fontdb/fontconfig"]
-wayland = ["copypasta/wayland", "fontdb/fontconfig"]
+x11 = ["copypasta/x11", "surfman/sm-x11"]
+wayland = ["copypasta/wayland"]
 capture=["webrender/capture", "webrender/serialize_program"]
 sw_compositor=["webrender/sw_compositor"]

--- a/rust_src/crates/webrender/src/font.rs
+++ b/rust_src/crates/webrender/src/font.rs
@@ -70,7 +70,12 @@ impl LispFontLike {
         } else {
             let symbol_or_string = tem.as_symbol_or_string();
             let string: LispStringRef = symbol_or_string.into();
-            return Some(string.to_string().replace("-", "\\-"));
+            let family_name = string.to_string().replace("-", "\\-");
+
+            #[cfg(all(unix, not(target_os = "macos")))]
+            let family_name = FontDB::fc_family_name(&family_name);
+
+            return Some(family_name);
         }
     }
 

--- a/rust_src/crates/webrender/src/term.rs
+++ b/rust_src/crates/webrender/src/term.rs
@@ -886,6 +886,8 @@ fn wr_create_terminal(mut dpyinfo: DisplayInfoRef) -> TerminalRef {
 }
 
 pub fn wr_term_init(display_name: LispObject) -> DisplayInfoRef {
+    log::info!("Emacs Webrender term init");
+
     let dpyinfo = Box::new(DisplayInfo::new());
     let mut dpyinfo_ref = DisplayInfoRef::new(Box::into_raw(dpyinfo));
 

--- a/rust_src/lib.rs
+++ b/rust_src/lib.rs
@@ -1,5 +1,39 @@
+#[cfg(debug_assertions)]
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+#[macro_use]
+extern crate emacs;
+
+use emacs::bindings::{main1, terminate_due_to_signal, will_dump_p};
+
 // Include the main c_exports file that holds the main rust_init_syms.
 // This function calls the other crates init_syms functions which contain
 // the generated bindings.
 #[cfg(not(test))]
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));
+
+#[no_mangle]
+#[allow(unused_doc_comments)]
+pub extern "C" fn main(argc: ::libc::c_int, argv: *mut *mut ::libc::c_char) -> ::libc::c_int {
+    unsafe {
+        if will_dump_p() {
+            return main1(argc, argv);
+        }
+    }
+
+    // install global collector configured based on RUST_LOG env var.
+    #[cfg(debug_assertions)]
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_env("EMACSNG_LOG"))
+        .init();
+
+    log::trace!("Emacs NG");
+
+    // tokio::spawn(async move {
+    unsafe { main1(argc, argv) };
+    // });
+
+    // emacs abort
+    unsafe { terminate_due_to_signal(libc::SIGABRT, 40) };
+    0
+}

--- a/rust_src/lib.rs
+++ b/rust_src/lib.rs
@@ -1,7 +1,5 @@
 #[cfg(debug_assertions)]
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-#[macro_use]
-extern crate emacs;
 
 use emacs::bindings::{main1, terminate_due_to_signal, will_dump_p};
 
@@ -20,7 +18,7 @@ pub extern "C" fn main(argc: ::libc::c_int, argv: *mut *mut ::libc::c_char) -> :
         }
     }
 
-    // install global collector configured based on RUST_LOG env var.
+    // install global collector configured based on EMACSNG_LOG env var.
     #[cfg(debug_assertions)]
     tracing_subscriber::registry()
         .with(fmt::layer())
@@ -29,9 +27,7 @@ pub extern "C" fn main(argc: ::libc::c_int, argv: *mut *mut ::libc::c_char) -> :
 
     log::trace!("Emacs NG");
 
-    // tokio::spawn(async move {
     unsafe { main1(argc, argv) };
-    // });
 
     // emacs abort
     unsafe { terminate_due_to_signal(libc::SIGABRT, 40) };

--- a/src/emacs.c
+++ b/src/emacs.c
@@ -1230,7 +1230,7 @@ maybe_load_seccomp (int argc, char **argv)
 #endif  /* SECCOMP_USABLE */
 
 int
-main (int argc, char **argv)
+main1 (int argc, char **argv)
 {
   /* Variable near the bottom of the stack, and aligned appropriately
      for pointers.  */

--- a/src/lisp.h
+++ b/src/lisp.h
@@ -3983,6 +3983,9 @@ extern Lisp_Object expt_integer (Lisp_Object, Lisp_Object);
 extern void syms_of_data (void);
 extern void swap_in_global_binding (struct Lisp_Symbol *);
 
+/* Defined in emacs.c */
+extern int main1 (int, char **);
+
 /* Defined in cmds.c */
 extern void syms_of_cmds (void);
 


### PR DESCRIPTION
So, before. We use fontdb load_system_fonts to load fonts to use while using fontkit to find
the family name to use.

But fontkit has full fontconfig support while fontdb uses hard-coded path, which would cause problem when fontkit return a name  hasn't been loaded by fontdb.

This patch uses my patched font_loader to get system font dirs for fontdb to use on Unix. Also it
uses font_loaders fontconfig to query font names.