### PR TITLE
feat(WR): use webrender with PGTK

### DIFF
--- a/Cargo.in
+++ b/Cargo.in
@@ -84,7 +84,7 @@ window-system-w32 = ["window-system"]
 # Use the haiku window system
 window-system-haiku = ["window-system"]
 # Use the pgtk window system
-window-system-pgtk = ["window-system"]
+window-system-pgtk = ["window-system", "emacs/window-system-pgtk",]
 # Build with git2rs support
 libgit = ["git", "ng-bindgen/libgit"]
 # Use the webrender

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ name = "emacs"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "gtk-sys",
  "lazy_static",
  "libc",
  "memoffset",
@@ -1496,6 +1497,16 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "gl_loader"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32d96dd5f881490e537041d5532320812ba096097f07fccb4626578da0b99d3"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5063,8 +5074,14 @@ dependencies = [
  "font-loader",
  "fontdb",
  "futures",
+ "gdk",
+ "gdk-sys",
+ "gdkwayland-sys",
+ "gl_loader",
  "gleam",
  "glutin",
+ "gtk",
+ "gtk-sys",
  "image 0.23.14",
  "lazy_static",
  "libc",

--- a/configure.ac
+++ b/configure.ac
@@ -1350,9 +1350,10 @@ AC_ARG_WITH([wr-gl],[AS_HELP_STRING([--with-wr-gl=KIT],
 	    y | ye | yes )	val=surfman ;;
 	    s | su | sur | surf | surfm | surfma | surfman )	val=surfman ;;
 	    g | gl | glu | glut | gluti | glutin )	val=glutin ;;
+	        gt | gtk | gtk3  )	val=gtk3 ;;
 	    * )
 AC_MSG_ERROR(['--with-wr-gl=$withval' is invalid;
-this option's value should be 'yes', 'surfman' or 'glutin'.
+this option's value should be 'yes', 'surfman', 'glutin' or 'gtk3'.
 'yes' and 'surfman' are synonyms.])
 	    ;;
 	  esac
@@ -6373,8 +6374,8 @@ AC_SUBST(WINIT_LIBS)
 WEBRENDER_LIBS=
 if test "${with_webrender}" = "yes" ; then
 
-  if test "${window_system}" != "winit" ; then
-     AC_MSG_ERROR(Webrender currently only support winit window system
+  if test "${window_system}" != "winit" && test "${window_system}" != "pgtk" ; then
+     AC_MSG_ERROR(Webrender currently only supports winit and pgtk window system.
      Current window system detection is $window_system. Please explicitly
      provide --with-winit.)
   fi
@@ -7101,10 +7102,36 @@ case "${window_system}" in
     ;;
     pgtk)
         CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"window-system-pgtk\", "
+	if test "${with_webrender}" = "yes" ; then
+	   WEBRENDER_EXTRA_FEATURES="\"wrterm/pgtk\", ${WEBRENDER_EXTRA_FEATURES}"
+	fi
     ;;
 esac
 if test "${with_webrender}" = "yes" ; then
    CARGO_DEFAULT_FEATURES="${CARGO_DEFAULT_FEATURES}\"webrender\", "
+   if test "X${with_wr_gl}" = "X"; then
+	case "${window_system}" in
+	    winit)
+		if test "X$with_winit" = "Xtao"; then
+		   with_wr_gl=gtk3
+		else
+		   with_wr_gl=surfman
+		fi
+	    ;;
+	    pgtk)
+		with_wr_gl=gtk3
+	    ;;
+	esac
+   fi
+
+   if test "${window_system}" = "pgtk" && test "${with_wr_gl}" != "gtk3"; then
+      AC_MSG_ERROR(PGTK with webrender currently only supports --with-wr-gl=gtk3.)
+   fi
+
+   if test "X$with_winit" = "Xwinit" && test "${with_wr_gl}" == "gtk3"; then
+      AC_MSG_ERROR(Winit does not support --with-wr-gl=gtk3.)
+   fi
+
    case "${with_wr_gl}" in
       glutin ) WEBRENDER_EXTRA_FEATURES="\"wrterm/glutin\", ${WEBRENDER_EXTRA_FEATURES}";;
       gtk3 ) WEBRENDER_EXTRA_FEATURES="\"wrterm/gtk3\", ${WEBRENDER_EXTRA_FEATURES}";;
@@ -7206,7 +7233,8 @@ if test "${HAVE_XFT}" = yes; then
     relevant development headers are installed).])
 fi
 
-if test "${HAVE_CAIRO}" = "yes" && test "${HAVE_HARFBUZZ}" = no; then
+if test "${HAVE_CAIRO}" = "yes" && test "${HAVE_HARFBUZZ}" = no \
+   && test "${with_webrender}" != "yes"; then
   AC_MSG_WARN([This configuration uses the Cairo graphics library,
     but not the HarfBuzz font shaping library (minimum version $harfbuzz_required_ver).
     We recommend the use of HarfBuzz when using Cairo, please install

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,10 @@
               drv = packages.emacsng;
               exePath = "/bin/emacs";
             };
+            emacsngWRPgtk = flake-utils.lib.mkApp {
+              drv = packages.emacsngWRPgtk;
+              exePath = "/bin/emacs";
+            };
             emacsng-noNativeComp = flake-utils.lib.mkApp {
               drv = packages.emacsng-noNativeComp;
               exePath = "/bin/emacs";
@@ -98,6 +102,7 @@
                 (pkgs)
                 emacsng
                 emacsng-noNativeComp
+                emacsngWRPgtk
                 ;
               default = pkgs.emacsng;
             };
@@ -294,6 +299,25 @@
           .overrideAttrs (
             oa: {
               name = "${oa.name}-no-native-comp";
+            }
+          )
+        );
+        emacsngWRPgtk = (
+          (
+            emacsng.override {
+              withPgtk = true;
+            }
+          )
+          .overrideAttrs (
+            oa: {
+              name = "${oa.name}-wr-pgtk";
+              configureFlags =
+              (
+                  prev.lib.subtractLists [
+                    "--with-winit"
+                  ]
+                  oa.configureFlags
+              );
             }
           )
         );

--- a/rust_src/crates/emacs/Cargo.toml
+++ b/rust_src/crates/emacs/Cargo.toml
@@ -12,6 +12,9 @@ libc = "0.2.95"
 lazy_static = "1.4.0"
 memoffset = "0.6.4"
 
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+gtk-sys = { version = "0.16", optional = true }
+
 [build-dependencies]
 bindgen = "0.64"
 regex = "1.6"
@@ -20,3 +23,4 @@ libc = "0.2"
 [features]
 window-system = []
 window-system-winit = [ "window-system"]
+window-system-pgtk = [ "window-system", "dep:gtk-sys"]

--- a/rust_src/crates/emacs/build.rs.in
+++ b/rust_src/crates/emacs/build.rs.in
@@ -237,6 +237,11 @@ fn generate_bindings() {
         builder = builder.clang_arg("-Ic:\\Program Files\\LLVM\\lib\\clang\\6.0.0\\include");
     }
 
+    #[cfg(feature = "window-system-pgtk")]
+    {
+        builder = builder.blocklist_item("GtkWidget");
+    }
+
     builder = builder
         .clang_arg("-Demacs")
         .clang_arg("-DEMACS_EXTERN_INLINE")
@@ -321,7 +326,7 @@ fn generate_bindings() {
     );
     let munged = re.unwrap().replace_all(&source, "");
     let mut file = File::create(out_path).unwrap();
-    write!(file, "use crate::{{\n    globals::emacs_globals,\n    sys::Lisp_Object,\n}};\n\nuse libc::{{timespec, fd_set, sigset_t}};\n").expect("Write error!");
+    write!(file, "use crate::{{\n    globals::emacs_globals,\n    sys::Lisp_Object,\n}};\n\nuse libc::{{timespec, fd_set, sigset_t}};\n\n#[cfg(feature = \"window-system-pgtk\")]\nuse gtk_sys::GtkWidget;\n").expect("Write error!");
     file.write_all(munged.into_owned().as_bytes()).unwrap();
 }
 

--- a/rust_src/crates/emacs/src/window.rs
+++ b/rust_src/crates/emacs/src/window.rs
@@ -30,9 +30,14 @@ impl LispWindowRef {
         self.frame.into()
     }
 
-    #[cfg(not(feature = "window-system-winit"))]
+    #[cfg(not(any(feature = "window-system-winit", feature = "window-system-pgtk")))]
     pub fn is_menu_bar(self) -> bool {
         unimplemented!();
+    }
+
+    #[cfg(feature = "window-system-pgtk")]
+    pub fn is_menu_bar(self) -> bool {
+        false
     }
 
     #[cfg(feature = "window-system-winit")]
@@ -40,9 +45,14 @@ impl LispWindowRef {
         false
     }
 
-    #[cfg(not(feature = "window-system-winit"))]
+    #[cfg(not(any(feature = "window-system-winit", feature = "window-system-pgtk")))]
     pub fn is_tool_bar(self) -> bool {
         unimplemented!();
+    }
+
+    #[cfg(feature = "window-system-pgtk")]
+    pub fn is_tool_bar(self) -> bool {
+        false
     }
 
     #[cfg(feature = "window-system-winit")]

--- a/rust_src/crates/webrender/Cargo.toml
+++ b/rust_src/crates/webrender/Cargo.toml
@@ -30,7 +30,7 @@ fontdb = "0.12"
 raw-window-handle = "0.5"
 errno = "0.2"
 euclid = "0.22"
-spin_sleep = { version = "1.1", optional = true }
+spin_sleep = { version = "1.1", optional = false }
 surfman = { version = "0.6", default-features = false, features = ["sm-raw-window-handle"], optional = true }
 glutin = { version = "0.30.6", optional = true }
 rustybuzz = "0.6"
@@ -59,6 +59,12 @@ cfg_aliases = "0.1"
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 font-loader = "0.11"
 wayland-sys = {version = "0.30", features = ["client", "dlopen"]}
+gtk = { version = "0.16", optional = true }
+gdk = { version = "0.16", optional = true }
+gtk-sys = { version = "0.16", optional = true }
+gdk-sys = { version = "0.16", optional = true }
+gdkwayland-sys = { version = "0.16", optional = true }
+gl_loader = { version = "0.1.2", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies.x11]
 features = ["xlib"]
@@ -87,13 +93,14 @@ wayland = [
 ]
 capture=["webrender/capture", "webrender/serialize_program"]
 sw_compositor=["webrender/sw_compositor"]
-pselect=["dep:spin_sleep", "dep:nix"]
+pselect=["dep:nix"]
 tokio=["dep:tokio"]
 glutin=["dep:glutin"]
 surfman=["dep:surfman", "dep:webrender_surfman"]
 winit=["dep:winit", "dep:copypasta", "emacs/window-system-winit"]
+gtk3=["dep:gtk", "dep:gdk", "dep:gl_loader"]
 tao=["dep:tao", "emacs/window-system-winit"]
-pgtk=[]
+pgtk=["dep:gtk", "dep:gtk-sys", "dep:gdkwayland-sys"]
 no_std = [
   "rustybuzz/libm",
 ]

--- a/rust_src/crates/webrender/build.rs
+++ b/rust_src/crates/webrender/build.rs
@@ -46,5 +46,6 @@ fn main() {
         use_pselect: { all(window_system_winit, feature = "pselect", not(use_tokio_select)) },
         use_surfman: { feature = "surfman" },
         use_glutin: { all(feature = "glutin", not(use_surfman)) },
+        use_gtk3: { all(feature = "gtk3", free_unix, not(use_surfman), not(use_glutin)) },
     }
 }

--- a/rust_src/crates/webrender/src/color.rs
+++ b/rust_src/crates/webrender/src/color.rs
@@ -1,3 +1,5 @@
+use emacs::frame::Lisp_Frame;
+use std::ffi::CStr;
 use webrender::api::ColorF;
 
 use emacs::bindings::Emacs_Color;
@@ -88,5 +90,21 @@ pub fn lookup_color_by_name_or_hex(color_string: &str) -> Option<ColorF> {
                     1.0,
                 )
             })
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn wr_parse_color(
+    _f: *mut Lisp_Frame,
+    color_name: *const ::libc::c_char,
+    xcolor: *mut Emacs_Color,
+) -> ::libc::c_int {
+    let color_name: &CStr = unsafe { CStr::from_ptr(color_name) };
+    let color_name: &str = color_name.to_str().unwrap();
+    if let Some(color) = lookup_color_by_name_or_hex(&format!("{}", color_name.to_owned())) {
+        color_to_xcolor(color, xcolor);
+        1
+    } else {
+        0
     }
 }

--- a/rust_src/crates/webrender/src/draw_canvas.rs
+++ b/rust_src/crates/webrender/src/draw_canvas.rs
@@ -1,3 +1,4 @@
+use crate::frame::LispFrameWindowSystemExt;
 use std::cmp::min;
 
 use webrender::{self, api::units::*, api::*};

--- a/rust_src/crates/webrender/src/font.rs
+++ b/rust_src/crates/webrender/src/font.rs
@@ -374,8 +374,8 @@ extern "C" fn open_font(frame: *mut frame, font_entity: LispObject, pixel_size: 
     let pixel_size = if pixel_size == 0 {
         // pixel_size here reflects to DPR 1 for webrender display, we have scale_factor from winit.
         // while pgtk/ns/w32 reflects to actual DPR on device by setting resx/resy to display
-        if !frame.output().get_font().is_null() {
-            frame.output().get_font().pixel_size as i64
+        if !frame.font().is_null() {
+            frame.font().pixel_size as i64
         } else {
             // fallback font size
             16

--- a/rust_src/crates/webrender/src/frame.rs
+++ b/rust_src/crates/webrender/src/frame.rs
@@ -1,7 +1,9 @@
+use super::font::FontRef;
 use crate::gl::context::GLContextTrait;
+use crate::output::Canvas;
 use crate::output::CanvasRef;
+use crate::output::OutputRef;
 use crate::window_system::frame::FrameId;
-use crate::window_system::output::OutputRef;
 use emacs::frame::LispFrameRef;
 use raw_window_handle::RawDisplayHandle;
 use raw_window_handle::RawWindowHandle;
@@ -10,30 +12,67 @@ use webrender::{self, api::units::*};
 
 use super::display_info::DisplayInfoRef;
 
-pub trait LispFrameExt {
+pub trait LispFrameWindowSystemExt {
     fn output(&self) -> OutputRef;
-    fn canvas(&self) -> CanvasRef;
     fn cursor_color(&self) -> ColorF;
     fn cursor_foreground_color(&self) -> ColorF;
-    fn display_info(&self) -> DisplayInfoRef;
     fn window_handle(&self) -> Option<RawWindowHandle>;
     fn display_handle(&self) -> Option<RawDisplayHandle>;
-    fn size(&self) -> DeviceIntSize;
     fn unique_id(&self) -> FrameId;
 }
-pub trait LispFrameGlExt {
+
+pub trait LispFrameExt {
+    fn canvas(&self) -> CanvasRef;
+    fn size(&self) -> DeviceIntSize;
+    fn font(&self) -> FontRef;
+    fn set_font(&mut self, font: FontRef);
+    fn fontset(&self) -> i32;
+    fn set_fontset(&mut self, fontset: i32);
+    fn display_info(&self) -> DisplayInfoRef;
+    fn set_display_info(&mut self, dpyinfo: DisplayInfoRef);
     fn create_gl_context(&self) -> crate::gl::context::GLContext;
 }
 
-impl LispFrameGlExt for LispFrameRef {
+impl LispFrameExt for LispFrameRef {
+    fn font(&self) -> FontRef {
+        FontRef::new(self.output().as_raw().font as *mut _)
+    }
+
+    fn fontset(&self) -> i32 {
+        self.output().as_raw().fontset
+    }
+
+    fn set_font(&mut self, mut font: FontRef) {
+        self.output().as_raw().font = font.as_mut();
+    }
+
+    fn set_fontset(&mut self, fontset: i32) {
+        self.output().as_raw().fontset = fontset;
+    }
+
+    fn display_info(&self) -> DisplayInfoRef {
+        self.output().display_info()
+    }
+
+    fn set_display_info(&mut self, mut dpyinfo: DisplayInfoRef) {
+        self.output().as_raw().display_info = dpyinfo.get_raw().as_mut();
+    }
+
+    fn size(&self) -> DeviceIntSize {
+        DeviceIntSize::new(self.pixel_width, self.pixel_height)
+    }
+
+    fn canvas(&self) -> CanvasRef {
+        if self.output().canvas().is_null() {
+            log::debug!("canvas_data empty");
+            let canvas = Box::new(Canvas::build(self.clone()));
+            self.output().inner().set_canvas(canvas);
+        }
+
+        self.output().canvas()
+    }
+
     fn create_gl_context(&self) -> crate::gl::context::GLContext {
-        let display_handle = self
-            .display_handle()
-            .expect("Failed to raw display handle from frame");
-        let window_handle = self
-            .window_handle()
-            .expect("Failed to get raw window handle from frame");
-        let size = self.size();
-        crate::gl::context::GLContext::build(size, display_handle, window_handle)
+        crate::gl::context::GLContext::build(self)
     }
 }

--- a/rust_src/crates/webrender/src/gl/context.rs
+++ b/rust_src/crates/webrender/src/gl/context.rs
@@ -1,18 +1,13 @@
 use crate::gl::context_impl::ContextImpl;
+use emacs::frame::LispFrameRef;
 use gleam::gl::Gl;
-use raw_window_handle::RawDisplayHandle;
-use raw_window_handle::RawWindowHandle;
 use std::rc::Rc;
 use webrender::{self, api::units::*};
 
 pub type GLContext = ContextImpl;
 
 pub trait GLContextTrait {
-    fn build(
-        size: DeviceIntSize,
-        display_handle: RawDisplayHandle,
-        window_handle: RawWindowHandle,
-    ) -> Self;
+    fn build(frame: &LispFrameRef) -> Self;
 
     fn bind_framebuffer(&mut self, gl: &mut Rc<dyn Gl>);
 

--- a/rust_src/crates/webrender/src/gl/context_impl/glutin.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/glutin.rs
@@ -1,4 +1,7 @@
+use crate::frame::LispFrameExt;
+use crate::frame::LispFrameWindowSystemExt;
 use crate::gl::context::GLContextTrait;
+use emacs::frame::LispFrameRef;
 use gleam::gl::ErrorCheckingGl;
 use glutin::{
     config::{Api, ConfigTemplateBuilder, GlConfig},
@@ -10,8 +13,6 @@ use glutin::{
     prelude::GlSurface,
     surface::{Surface, SurfaceAttributesBuilder, WindowSurface},
 };
-use raw_window_handle::RawDisplayHandle;
-use raw_window_handle::RawWindowHandle;
 use webrender::api::units::DeviceIntSize;
 
 use std::{ffi::CString, num::NonZeroU32};
@@ -27,12 +28,17 @@ pub struct ContextImpl {
 }
 
 impl GLContextTrait for ContextImpl {
-    fn build(
-        size: DeviceIntSize,
-        display_handle: RawDisplayHandle,
-        window_handle: RawWindowHandle,
-    ) -> Self {
+    fn build(frame: &LispFrameRef) -> Self {
         log::trace!("Initialize OpenGL context using Glutin");
+
+        let display_handle = frame
+            .display_handle()
+            .expect("Failed to raw display handle from frame");
+        let window_handle = frame
+            .window_handle()
+            .expect("Failed to get raw window handle from frame");
+        let size = frame.size();
+
         let width = NonZeroU32::new(size.width as u32).unwrap();
         let height = NonZeroU32::new(size.height as u32).unwrap();
 

--- a/rust_src/crates/webrender/src/gl/context_impl/gtk3.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/gtk3.rs
@@ -1,0 +1,128 @@
+use crate::frame::LispFrameExt;
+use crate::frame::LispFrameWindowSystemExt;
+use crate::gl::context::GLContextTrait;
+use emacs::frame::LispFrameRef;
+use gleam::gl::ErrorCheckingGl;
+use gleam::gl::Gl;
+use gleam::gl::GlFns;
+use gleam::gl::GlesFns;
+use gtk::builders::GLAreaBuilder;
+use gtk::prelude::*;
+use gtk::GLArea;
+use std::rc::Rc;
+use webrender::api::units::DeviceIntSize;
+
+pub struct ContextImpl {
+    area: GLArea,
+    #[cfg(window_system_pgtk)]
+    fixed: gtk::Fixed,
+}
+
+/// The API (OpenGL or OpenGL ES).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GLApi {
+    /// OpenGL (full or desktop OpenGL).
+    GL,
+    /// OpenGL ES (embedded OpenGL).
+    GLES,
+}
+
+impl ContextImpl {
+    #[inline]
+    fn get_proc_address(&self, addr: &str) -> *const core::ffi::c_void {
+        gl_loader::get_proc_address(addr) as *const _
+    }
+
+    pub fn raw_handle(&self) -> &GLArea {
+        &self.area
+    }
+
+    #[inline]
+    fn gl_api(&self) -> GLApi {
+        // TODO detect es
+        // https://lazka.github.io/pgi-docs/Gtk-3.0/classes/GLArea.html#Gtk.GLArea.set_use_es
+
+        GLApi::GL
+    }
+}
+
+impl GLContextTrait for ContextImpl {
+    fn build(frame: &LispFrameRef) -> Self {
+        let size = frame.size();
+        // TODO config of pf_reqs and gl_attr
+        let area = GLAreaBuilder::new()
+            .width_request(size.width)
+            .height_request(size.height)
+            .visible(true)
+            .has_alpha(true)
+            .build();
+
+        #[cfg(use_tao)]
+        {
+            use crate::window_system::api::platform::unix::WindowExtUnix;
+            let frame_inner = frame.output().inner();
+            let window = frame_inner.window.as_ref().expect("No window");
+
+            let gtkwin = window.gtk_window();
+
+            let vbox = gtkwin
+                .children()
+                .pop()
+                .unwrap()
+                .downcast::<gtk::Box>()
+                .unwrap();
+            vbox.pack_start(&area, true, true, 0);
+            area.grab_focus();
+            gtkwin.show_all();
+        }
+
+        #[cfg(window_system_pgtk)]
+        let fixed = {
+            use gtk::glib::translate::FromGlibPtrNone;
+            let wfixed = frame.output().as_raw().edit_widget;
+            let fixed: gtk::Fixed = unsafe { gtk::Widget::from_glib_none(wfixed).unsafe_cast() };
+            fixed.put(&area, 0, 0);
+            area.grab_focus();
+            fixed
+        };
+
+        gl_loader::init_gl();
+        area.make_current();
+        #[cfg(window_system_pgtk)]
+        return Self { area, fixed };
+        #[cfg(use_tao)]
+        return Self { area };
+    }
+
+    fn bind_framebuffer(&mut self, _gl: &mut Rc<dyn Gl>) {
+        self.area.attach_buffers();
+    }
+
+    #[inline]
+    fn swap_buffers(&self) {
+        // GTK swaps the buffers after each "render" signal itself
+        self.area.queue_render();
+    }
+
+    // Ignored because widget will be resized automatically
+    fn resize(&self, _size: &DeviceIntSize) {
+        #[cfg(window_system_pgtk)]
+        {
+            self.area.set_width_request(_size.width);
+            self.area.set_height_request(_size.height);
+            self.fixed.move_(&self.area, 0, 0);
+        }
+    }
+
+    fn ensure_is_current(&mut self) {
+        self.area.make_current();
+    }
+
+    fn load_gl(&self) -> Rc<dyn Gl> {
+        let gl = match self.gl_api() {
+            GLApi::GL => unsafe { GlFns::load_with(|s| self.get_proc_address(s)) },
+            GLApi::GLES => unsafe { GlesFns::load_with(|s| self.get_proc_address(s)) },
+        };
+        ErrorCheckingGl::wrap(gl)
+    }
+}

--- a/rust_src/crates/webrender/src/gl/context_impl/surfman.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/surfman.rs
@@ -1,6 +1,7 @@
+use crate::frame::LispFrameExt;
+use crate::frame::LispFrameWindowSystemExt;
 use crate::gl::context::GLContextTrait;
-use raw_window_handle::RawDisplayHandle;
-use raw_window_handle::RawWindowHandle;
+use emacs::frame::LispFrameRef;
 use webrender::api::units::DeviceIntSize;
 
 use surfman::{Connection, GLApi, SurfaceType};
@@ -29,12 +30,16 @@ impl ContextImpl {
 }
 
 impl GLContextTrait for ContextImpl {
-    fn build(
-        size: DeviceIntSize,
-        display_handle: RawDisplayHandle,
-        window_handle: RawWindowHandle,
-    ) -> Self {
+    fn build(frame: &LispFrameRef) -> Self {
         log::trace!("Initialize OpenGL context using Surfman");
+
+        let display_handle = frame
+            .display_handle()
+            .expect("Failed to raw display handle from frame");
+        let window_handle = frame
+            .window_handle()
+            .expect("Failed to get raw window handle from frame");
+        let size = frame.size();
 
         let connection = match Connection::from_raw_display_handle(display_handle) {
             Ok(connection) => connection,

--- a/rust_src/crates/webrender/src/lib.rs
+++ b/rust_src/crates/webrender/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 extern crate emacs;
 extern crate lisp_macros;
+#[cfg(window_system_winit)]
 #[macro_use]
 extern crate lisp_util;
 extern crate colors;
@@ -40,6 +41,8 @@ pub mod select {
 #[cfg(have_window_system)]
 pub mod window_system {
 
+    #[cfg(window_system_pgtk)]
+    pub use crate::window_system::pgtk::*;
     #[cfg(window_system_winit)]
     pub use crate::window_system::winit::*;
     #[cfg(window_system_winit)]
@@ -47,18 +50,31 @@ pub mod window_system {
 
     // frame
     pub mod frame {
+        #[cfg(window_system_pgtk)]
+        pub use crate::window_system::pgtk::frame::*;
         #[cfg(window_system_winit)]
         pub use crate::window_system::winit::frame::*;
     }
 
     pub mod display_info {
+        #[cfg(window_system_pgtk)]
+        pub use crate::window_system::pgtk::display_info::*;
         #[cfg(window_system_winit)]
         pub use crate::window_system::winit::display_info::*;
     }
 
     pub mod output {
+        #[cfg(window_system_pgtk)]
+        pub use crate::window_system::pgtk::output::*;
         #[cfg(window_system_winit)]
         pub use crate::window_system::winit::output::*;
+    }
+
+    #[cfg(window_system_pgtk)]
+    mod pgtk {
+        pub mod display_info;
+        pub mod frame;
+        pub mod output;
     }
 
     #[cfg(window_system_winit)]
@@ -120,11 +136,15 @@ pub mod gl {
     pub mod context_impl {
         #[cfg(use_glutin)]
         pub use crate::gl::context_impl::glutin::*;
+        #[cfg(use_gtk3)]
+        pub use crate::gl::context_impl::gtk3::*;
         #[cfg(use_surfman)]
         pub use crate::gl::context_impl::surfman::*;
 
         #[cfg(use_glutin)]
         pub mod glutin;
+        #[cfg(use_gtk3)]
+        pub mod gtk3;
         #[cfg(use_surfman)]
         pub mod surfman;
     }
@@ -137,6 +157,7 @@ mod platform {
 #[cfg(all(window_system_winit, macos_platform))]
 pub use crate::platform::macos;
 
+pub use crate::color::*;
 pub use crate::font::*;
 pub use crate::term::*;
 #[cfg(window_system_winit)]
@@ -145,4 +166,8 @@ pub use crate::window_system::term::*;
 pub use crate::wrterm::*;
 
 #[cfg(not(test))]
+#[cfg(window_system_winit)]
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));
+#[no_mangle]
+#[cfg(not(window_system_winit))]
+pub extern "C" fn wrterm_init_syms() {}

--- a/rust_src/crates/webrender/src/output.rs
+++ b/rust_src/crates/webrender/src/output.rs
@@ -1,7 +1,12 @@
-use crate::frame::LispFrameGlExt;
+use super::display_info::DisplayInfoRef;
+use super::font::FontRef;
 use crate::gl::context::GLContextTrait;
+use crate::window_system::output::output;
+use crate::window_system::output::OutputInner;
+use crate::window_system::output::OutputInnerRef;
 use emacs::lisp::ExternalPtr;
 use std::fmt;
+use std::ptr;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use crate::frame::LispFrameExt;
@@ -499,6 +504,79 @@ impl Canvas {
 }
 
 pub type CanvasRef = ExternalPtr<Canvas>;
+
+#[derive(Default)]
+#[repr(transparent)]
+pub struct Output(output);
+pub type OutputRef = ExternalPtr<Output>;
+
+impl Output {
+    pub fn new() -> Self {
+        let ret = Output::default();
+        ret
+    }
+
+    pub fn empty_inner(&mut self) {
+        let _ = unsafe { Box::from_raw(self.inner().as_mut()) };
+        self.0.inner = ptr::null_mut();
+    }
+
+    pub fn set_inner(&mut self, inner: Box<OutputInner>) {
+        self.0.inner = Box::into_raw(inner) as *mut libc::c_void;
+    }
+
+    pub fn set_font(&mut self, mut font: FontRef) {
+        self.0.font = font.as_mut();
+    }
+
+    pub fn set_fontset(&mut self, fontset: i32) {
+        self.0.fontset = fontset;
+    }
+
+    pub fn display_info(&self) -> DisplayInfoRef {
+        DisplayInfoRef::new(self.0.display_info as *mut _)
+    }
+
+    pub fn canvas(&mut self) -> CanvasRef {
+        self.inner().canvas
+    }
+
+    pub fn inner(&mut self) -> OutputInnerRef {
+        if self.0.inner.is_null() {
+            self.set_inner(Box::new(OutputInner::default()));
+        }
+
+        OutputInnerRef::new(self.0.inner as *mut OutputInner)
+    }
+
+    pub fn as_raw(&mut self) -> ExternalPtr<output> {
+        (&mut self.0 as *mut output).into()
+    }
+}
+
+impl Drop for Output {
+    fn drop(&mut self) {
+        if self.0.inner != ptr::null_mut() {
+            if OutputInnerRef::new(self.0.inner as *mut OutputInner)
+                .canvas
+                .as_mut()
+                != ptr::null_mut()
+            {
+                unsafe {
+                    let _ = Box::from_raw(
+                        OutputInnerRef::new(self.0.inner as *mut OutputInner)
+                            .canvas
+                            .as_mut(),
+                    );
+                }
+            }
+
+            unsafe {
+                let _ = Box::from_raw(self.0.inner as *mut OutputInner);
+            }
+        }
+    }
+}
 
 struct Notifier {}
 

--- a/rust_src/crates/webrender/src/select/plain.rs
+++ b/rust_src/crates/webrender/src/select/plain.rs
@@ -15,8 +15,6 @@ use crate::window_system::api::{
     platform::run_return::EventLoopExtRunReturn,
 };
 use libc::{fd_set, sigset_t, timespec};
-#[cfg(use_tao)]
-use tao::platform::unix::EventLoopWindowTargetExtUnix;
 
 use emacs::bindings::make_timespec;
 

--- a/rust_src/crates/webrender/src/window_system/pgtk/display_info.rs
+++ b/rust_src/crates/webrender/src/window_system/pgtk/display_info.rs
@@ -1,0 +1,1 @@
+pub type display_info = emacs::bindings::pgtk_display_info;

--- a/rust_src/crates/webrender/src/window_system/pgtk/frame.rs
+++ b/rust_src/crates/webrender/src/window_system/pgtk/frame.rs
@@ -1,0 +1,77 @@
+use crate::color::pixel_to_color;
+use crate::output::Output;
+use crate::output::OutputRef;
+use emacs::frame::LispFrameRef;
+use raw_window_handle::RawDisplayHandle;
+use raw_window_handle::RawWindowHandle;
+use webrender::api::ColorF;
+
+use crate::frame::LispFrameWindowSystemExt;
+
+pub type FrameId = u64;
+
+impl LispFrameWindowSystemExt for LispFrameRef {
+    fn output(&self) -> OutputRef {
+        return OutputRef::new(unsafe { self.output_data.pgtk } as *mut Output);
+    }
+
+    fn cursor_color(&self) -> ColorF {
+        let color = self.output().as_raw().cursor_color;
+        pixel_to_color(color)
+    }
+
+    fn cursor_foreground_color(&self) -> ColorF {
+        let color = self.output().as_raw().cursor_foreground_color;
+        pixel_to_color(color)
+    }
+
+    fn window_handle(&self) -> Option<RawWindowHandle> {
+        use raw_window_handle::WaylandWindowHandle;
+        use std::ptr;
+        let mut output = self.output();
+        let widget = output.as_raw().edit_widget;
+        if widget != ptr::null_mut() {
+            let gwin = unsafe { gtk_sys::gtk_widget_get_window(widget) };
+            let surface = unsafe {
+                gdk_wayland_sys::gdk_wayland_window_get_wl_surface(
+                    gwin as *mut _ as *mut gdk_wayland_sys::GdkWaylandWindow,
+                )
+            };
+            log::debug!("surface: {:?}", surface);
+            let mut window_handle = WaylandWindowHandle::empty();
+            window_handle.surface = surface;
+            return Some(RawWindowHandle::Wayland(window_handle));
+        }
+        return None;
+    }
+
+    fn display_handle(&self) -> Option<RawDisplayHandle> {
+        use raw_window_handle::WaylandDisplayHandle;
+
+        let display = unsafe {
+            self.output()
+                .display_info()
+                .get_raw()
+                .__bindgen_anon_1
+                .display
+        };
+        let wl_display = unsafe {
+            gdk_wayland_sys::gdk_wayland_display_get_wl_display(
+                display as *mut _ as *mut gdk_wayland_sys::GdkWaylandDisplay,
+            )
+        };
+        let mut display_handle = WaylandDisplayHandle::empty();
+        display_handle.display = wl_display;
+        return Some(RawDisplayHandle::Wayland(display_handle));
+    }
+
+    fn unique_id(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
+        use std::hash::Hasher;
+
+        let mut hasher = DefaultHasher::new();
+        self.window_handle().hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/rust_src/crates/webrender/src/window_system/pgtk/output.rs
+++ b/rust_src/crates/webrender/src/window_system/pgtk/output.rs
@@ -1,0 +1,28 @@
+use emacs::lisp::ExternalPtr;
+
+use crate::output::Canvas;
+use crate::output::CanvasRef;
+
+use std::ptr;
+
+pub struct OutputInner {
+    pub canvas: CanvasRef,
+}
+
+impl Default for OutputInner {
+    fn default() -> Self {
+        OutputInner {
+            canvas: CanvasRef::new(ptr::null_mut() as *mut _ as *mut Canvas),
+        }
+    }
+}
+
+impl OutputInner {
+    pub fn set_canvas(&mut self, canvas: Box<Canvas>) {
+        self.canvas = CanvasRef::new(Box::into_raw(canvas));
+    }
+}
+
+pub type OutputInnerRef = ExternalPtr<OutputInner>;
+
+pub type output = emacs::bindings::pgtk_output;

--- a/rust_src/crates/webrender/src/window_system/winit/output.rs
+++ b/rust_src/crates/webrender/src/window_system/winit/output.rs
@@ -7,9 +7,6 @@ use raw_window_handle::RawWindowHandle;
 
 use std::ptr;
 
-use crate::display_info::DisplayInfoRef;
-use crate::font::FontRef;
-
 pub struct OutputInner {
     pub background_color: ColorF,
     pub cursor_color: ColorF,
@@ -67,88 +64,3 @@ impl OutputInner {
 pub type OutputInnerRef = ExternalPtr<OutputInner>;
 
 pub type output = emacs::bindings::winit_output;
-
-#[derive(Default)]
-#[repr(transparent)]
-pub struct Output(output);
-pub type OutputRef = ExternalPtr<Output>;
-
-impl Output {
-    pub fn new() -> Self {
-        let ret = Output::default();
-        ret
-    }
-
-    pub fn empty_inner(&mut self) {
-        let _ = unsafe { Box::from_raw(self.get_inner().as_mut()) };
-        self.0.inner = ptr::null_mut();
-    }
-
-    pub fn set_inner(&mut self, inner: Box<OutputInner>) {
-        self.0.inner = Box::into_raw(inner) as *mut libc::c_void;
-    }
-
-    pub fn set_display_info(&mut self, mut dpyinfo: DisplayInfoRef) {
-        self.0.display_info = dpyinfo.get_raw().as_mut();
-    }
-
-    pub fn set_font(&mut self, mut font: FontRef) {
-        self.0.font = font.as_mut();
-    }
-
-    pub fn set_fontset(&mut self, fontset: i32) {
-        self.0.fontset = fontset;
-    }
-
-    pub fn display_info(&self) -> DisplayInfoRef {
-        DisplayInfoRef::new(self.0.display_info as *mut _)
-    }
-
-    pub fn get_font(&self) -> FontRef {
-        FontRef::new(self.0.font as *mut _)
-    }
-
-    pub fn get_fontset(&self) -> i32 {
-        self.0.fontset
-    }
-
-    pub fn get_canvas(&mut self) -> CanvasRef {
-        self.get_inner().canvas
-    }
-
-    pub fn get_inner(&mut self) -> OutputInnerRef {
-        if self.0.inner.is_null() {
-            self.set_inner(Box::new(OutputInner::default()));
-        }
-
-        OutputInnerRef::new(self.0.inner as *mut OutputInner)
-    }
-
-    pub fn as_raw(&mut self) -> ExternalPtr<output> {
-        (&mut self.0 as *mut output).into()
-    }
-}
-
-impl Drop for Output {
-    fn drop(&mut self) {
-        if self.0.inner != ptr::null_mut() {
-            if OutputInnerRef::new(self.0.inner as *mut OutputInner)
-                .canvas
-                .as_mut()
-                != ptr::null_mut()
-            {
-                unsafe {
-                    let _ = Box::from_raw(
-                        OutputInnerRef::new(self.0.inner as *mut OutputInner)
-                            .canvas
-                            .as_mut(),
-                    );
-                }
-            }
-
-            unsafe {
-                let _ = Box::from_raw(self.0.inner as *mut OutputInner);
-            }
-        }
-    }
-}

--- a/rust_src/crates/webrender/src/window_system/winit/term.rs
+++ b/rust_src/crates/webrender/src/window_system/winit/term.rs
@@ -2,6 +2,7 @@ use super::frame::LispFrameWinitExt;
 use crate::event_loop::flush_events;
 use crate::event_loop::poll_a_event;
 use crate::event_loop::WrEventLoop;
+use crate::frame::LispFrameWindowSystemExt;
 use crate::input::InputProcessor;
 use crate::term::*;
 #[cfg(use_winit)]
@@ -490,14 +491,10 @@ extern "C" fn winit_mouse_position(
 extern "C" fn winit_destroy_frame(f: *mut Lisp_Frame) {
     let frame: LispFrameRef = f.into();
     let mut output = frame.output();
-    let mut data = frame.canvas();
     let mut display_info = frame.display_info();
     let unique_id = frame.unique_id();
 
     display_info.get_inner().frames.remove(&unique_id);
-
-    // Take back output ownership and destroy it
-    let _ = unsafe { Box::from_raw(data.as_mut()).deinit() };
     output.empty_inner();
 }
 

--- a/rust_src/wrapper.h
+++ b/rust_src/wrapper.h
@@ -63,3 +63,6 @@
 #ifdef HAVE_WINIT
 # include "wrterm.h"
 #endif
+#ifdef HAVE_PGTK
+# include "pgtkterm.h"
+#endif

--- a/src/frame.c
+++ b/src/frame.c
@@ -906,6 +906,10 @@ adjust_frame_size (struct frame *f, int new_text_width, int new_text_height,
 /**   f->resized_p = (new_native_width != old_native_width **/
 /** 		  || new_native_height != old_native_height); **/
 
+#if defined (USE_WEBRENDER) || defined (HAVE_PGTK)
+  wr_adjust_canvas_size (f, new_native_width, new_native_height);
+#endif
+
   unblock_input ();
 
 #ifdef HAVE_WINDOW_SYSTEM

--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -524,8 +524,10 @@ pgtk_change_tab_bar_height (struct frame *f, int height)
      here.  */
   adjust_frame_glyphs (f);
   SET_FRAME_GARBAGED (f);
+#ifndef USE_WEBRENDER
   if (FRAME_X_WINDOW (f))
     pgtk_clear_under_internal_border (f);
+#endif /* USE_WEBRENDER */
 }
 
 /* Set the pixel height of the tool bar of frame F to HEIGHT.  */
@@ -1385,10 +1387,14 @@ This function is an internal primitive--use `make-frame' instead.  */ )
       specbind (Qx_resource_name, name);
     }
 
+#ifndef USE_WEBRENDER
   register_font_driver (&ftcrfont_driver, f);
 #ifdef HAVE_HARFBUZZ
   register_font_driver (&ftcrhbfont_driver, f);
 #endif	/* HAVE_HARFBUZZ */
+#else
+register_ttf_parser_font_driver(f);
+#endif  /* USE_WEBRENDER */
 
   image_cache_refcount =
     FRAME_IMAGE_CACHE (f) ? FRAME_IMAGE_CACHE (f)->refcount : 0;
@@ -2335,7 +2341,6 @@ DEFUN ("xw-color-defined-p", Fxw_color_defined_p, Sxw_color_defined_p, 1, 2, 0,
     return Qnil;
 }
 
-
 DEFUN ("xw-color-values", Fxw_color_values, Sxw_color_values, 1, 2, 0,
        doc: /* Internal function called by `color-values', which see.  */)
   (Lisp_Object color, Lisp_Object frame)
@@ -2742,10 +2747,14 @@ x_create_tip_frame (struct pgtk_display_info *dpyinfo, Lisp_Object parms, struct
       specbind (Qx_resource_name, name);
     }
 
+#ifndef USE_WEBRENDER
   register_font_driver (&ftcrfont_driver, f);
 #ifdef HAVE_HARFBUZZ
   register_font_driver (&ftcrhbfont_driver, f);
 #endif	/* HAVE_HARFBUZZ */
+#else
+register_ttf_parser_font_driver(f);
+#endif  /* USE_WEBRENDER */
 
   image_cache_refcount =
     FRAME_IMAGE_CACHE (f) ? FRAME_IMAGE_CACHE (f)->refcount : 0;

--- a/src/pgtkgui.h
+++ b/src/pgtkgui.h
@@ -45,7 +45,9 @@ typedef unichar XChar2b;
 
 typedef struct _GdkCursor *Emacs_Cursor;
 
+#ifndef USE_WEBRENDER
 typedef void *Color;
+#endif  /* USE_WEBRENDER */
 typedef int Window;
 typedef struct _GdkDisplay Display;
 
@@ -55,11 +57,13 @@ typedef void *XrmDatabase;
 
 /* Some sort of attempt to normalize rectangle handling.. seems a bit much
    for what is accomplished.  */
+#ifndef USE_WEBRENDER
 typedef struct
 {
   int x, y;
   unsigned width, height;
 } XRectangle;
+#endif  /* USE_WEBRENDER */
 
 /* This stuff is needed by frame.c.  */
 #define ForgetGravity		0
@@ -96,6 +100,7 @@ typedef struct
 #define PWinGravity	(1L << 9)	/* program specified window gravity */
 
 
+#ifndef USE_WEBRENDER
 #define NativeRectangle XRectangle
 
 #define CONVERT_TO_EMACS_RECT(xr, nr)		\
@@ -115,5 +120,6 @@ typedef struct
    (nr).y      = (py),					\
    (nr).width  = (pwidth),				\
    (nr).height = (pheight))
+#endif  /* USE_WEBRENDER */
 
 #endif /* __PGTKGUI_H__ */

--- a/src/pgtkterm.h
+++ b/src/pgtkterm.h
@@ -121,6 +121,12 @@ struct scroll_bar
 
 struct pgtk_display_info
 {
+
+#ifdef USE_WEBRENDER
+  /* Inner perporty in Rust */
+  void *inner;
+#endif  /*USE_WEBRENDER*/
+
   /* Chain of all pgtk_display_info structures.  */
   struct pgtk_display_info *next;
 
@@ -258,6 +264,12 @@ extern struct pgtk_display_info *x_display_list;
 
 struct pgtk_output
 {
+
+#ifdef USE_WEBRENDER
+  /* Inner perporty in Rust */
+  void *inner;
+#endif  /*USE_WEBRENDER*/
+
   unsigned long foreground_color;
   unsigned long background_color;
   void *toolbar;
@@ -487,8 +499,10 @@ enum
 #define FRAME_FONTSET(f) (FRAME_X_OUTPUT (f)->fontset)
 
 #define FRAME_BASELINE_OFFSET(f) (FRAME_X_OUTPUT (f)->baseline_offset)
+#ifndef USE_WEBRENDER
 #define BLACK_PIX_DEFAULT(f) 0x000000
 #define WHITE_PIX_DEFAULT(f) 0xFFFFFF
+#endif  /* USE_WEBRENDER */
 
 /* First position where characters can be shown (instead of scrollbar, if
    it is on left. */
@@ -650,6 +664,10 @@ extern bool pgtk_text_icon (struct frame *, const char *);
 
 extern double pgtk_frame_scale_factor (struct frame *);
 extern int pgtk_emacs_to_gtk_modifiers (struct pgtk_display_info *, int);
+
+#ifdef USE_WEBRENDER
+#include "webrender_ffi.h"
+#endif  /* USE_WEBRENDER */
 
 #endif /* HAVE_PGTK */
 #endif /* _PGTKTERM_H_ */

--- a/src/webrender_ffi.h
+++ b/src/webrender_ffi.h
@@ -41,6 +41,13 @@ extern void
 wr_update_end (struct frame *f);
 extern Lisp_Object wr_new_font (struct frame *f, Lisp_Object font_object, int fontset);
 
+extern int
+wr_parse_color (struct frame *f, const char *color_name,
+		Emacs_Color * color);
+void
+wr_adjust_canvas_size (struct frame *f, int new_width, int new_height);
+
+
 extern void syms_of_webrender(void);
 
 #define BLACK_PIX_DEFAULT(f) 0


### PR DESCRIPTION
This PR

- Added gtk3 gl_area support for winit (tao) build.(`--with-winit=t --with-wr-gl=gt`)
- Added initial support for build PGTK with Webrender. (`--with-pgtk --with-webrender`)

For the PGTK with Webrender. It kind of just works.
I've tested the child-frame/context-menu. Since child-frame is the one I want most when using WR.