### PR TITLE
fix: avoid window system when running in terminal

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -906,7 +906,7 @@ adjust_frame_size (struct frame *f, int new_text_width, int new_text_height,
 /**   f->resized_p = (new_native_width != old_native_width **/
 /** 		  || new_native_height != old_native_height); **/
 
-#if defined (USE_WEBRENDER) || defined (HAVE_PGTK)
+#if defined (USE_WEBRENDER) && defined (HAVE_PGTK)
   wr_adjust_canvas_size (f, new_native_width, new_native_height);
 #endif
 


### PR DESCRIPTION
closes #502 .

I've also dropped the explicit test for `HAVE_PGTK` here, as it doesn't make sense to call `wrterm` functions unless we have webrender.  I don't know if you can still build non-webrender pgtk with this fork, but it seems worth leaving the possibility in place if we can.

*WHY* isn't it documented anywhere that frame->parent_frame being non-nil is the test for a graphical frame?!  Took me a good twenty minutes to persuade myself it really was always true.

More interestingly, why did this work before?  `emacs -nw` always failed if it couldn't get the graphical display, but other than that it was fine.  This way it works over ssh again :D