### PR TITLE
WR: Scale glyphs all together just before rendering

### DIFF
--- a/rust_src/crates/webrender/src/cursor.rs
+++ b/rust_src/crates/webrender/src/cursor.rs
@@ -1,3 +1,4 @@
+use crate::frame::LispFrameExt;
 use crate::{renderer::Renderer, util::HandyDandyRectBuilder};
 
 use emacs::{
@@ -35,12 +36,12 @@ pub fn draw_hollow_box_cursor(mut window: LispWindowRef, row: *mut glyph_row) {
     let width = window.phys_cursor_width;
 
     let mut frame = window.get_frame();
-
-    let cursor_rect = (x, y).by(width, height);
+    let scale = frame.canvas().scale();
+    let cursor_rect = (x, y).by(width, height, scale);
 
     let window_rect = {
         let (x, y, width, height) = window.area_box(glyph_row_area::ANY_AREA);
-        (x, y).by(width, height)
+        (x, y).by(width, height, scale)
     };
 
     frame.draw_hollow_box_cursor(cursor_rect, window_rect);

--- a/rust_src/crates/webrender/src/font.rs
+++ b/rust_src/crates/webrender/src/font.rs
@@ -1,10 +1,5 @@
-use crate::frame::LispFrameWindowSystemExt;
-use crate::window_system::frame::FrameId;
-use emacs::font::LispFontRef;
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::OnceLock;
-use ttf_parser::LineMetrics;
 
 use std::ffi::CString;
 use std::ptr;
@@ -31,24 +26,6 @@ use emacs::{
 };
 
 use crate::{font_db::FontDB, font_db::FontDescriptor, frame::LispFrameExt};
-
-pub fn wrfonts() -> &'static Mutex<Vec<LispObject>> {
-    static WRFONTS: OnceLock<Mutex<Vec<LispObject>>> = OnceLock::new();
-    WRFONTS.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-pub fn update_wrfonts(id: FrameId, device_pixel_ratio: f32) {
-    let wr_fonts = wrfonts().lock().unwrap().clone();
-    log::debug!("update wrfonts {device_pixel_ratio:?} {:?}", wr_fonts.len());
-    for font in wr_fonts.iter() {
-        let font = LispFontRef::from_vectorlike(font.as_vectorlike().unwrap()).as_font_mut();
-        let mut wr_font = WRFontRef::new(font as *mut WRFont);
-        if wr_font.frame_id != id {
-            continue;
-        }
-        wr_font.update(device_pixel_ratio);
-    }
-}
 
 static mut FONT_DB: OnceLock<FontDB> = OnceLock::new();
 impl FontDB<'static> {
@@ -346,20 +323,13 @@ pub struct WRFont {
     // extend basic font
     pub font: font,
 
+    pub scale: f32,
+
     pub face_index: u32,
 
     pub face_id: fontdb::ID,
 
     pub instance_keys: HashMap<u64, FontInstanceKey>,
-
-    pub frame_id: FrameId,
-    device_pixel_ratio: f32,
-
-    units_per_em: i32,
-    underline_metrics: LineMetrics,
-    ascent: i16,
-    descent: i16,
-    average_width: u16,
 }
 
 impl WRFont {
@@ -377,78 +347,15 @@ impl WRFont {
                 .map(|i| {
                     font.face
                         .glyph_hor_advance(ttf_parser::GlyphId(i as u16))
-                        .map(|a| (a as f32 * self.scale()).round() as i32)
+                        .map(|a| (a as f32 * self.scale).round() as i32)
                 })
                 .collect();
         }
         Vec::new()
     }
-    pub fn device_pixel_ratio(&self) -> f32 {
-        self.device_pixel_ratio
-    }
-
-    pub fn glyph_size(&self) -> f32 {
-        self.font.pixel_size as f32 * self.device_pixel_ratio()
-    }
-
-    pub fn scale(&self) -> f32 {
-        self.glyph_size() / self.units_per_em as f32
-    }
-
-    pub fn average_width(&self) -> i32 {
-        (self.average_width as f32 * self.scale()) as i32
-    }
-
-    pub fn ascent(&self) -> i32 {
-        (self.scale() * self.ascent as f32).round() as i32
-    }
-
-    pub fn descent(&self) -> i32 {
-        (-self.scale() * self.descent as f32).round() as i32
-    }
-
-    pub fn space_width(&self) -> i32 {
-        self.average_width()
-    }
-
-    pub fn max_width(&self) -> i32 {
-        self.average_width()
-    }
-
-    pub fn underline_thickness(&self) -> i32 {
-        (self.scale() * self.underline_metrics.thickness as f32) as i32
-    }
-
-    pub fn underline_position(&self) -> i32 {
-        (self.scale() * self.underline_metrics.position as f32) as i32
-    }
-
-    pub fn height(&self) -> i32 {
-        (self.scale() * (self.ascent - self.descent) as f32).round() as i32
-    }
-
-    pub fn baseline_offset(&self) -> i32 {
-        0
-    }
-
-    pub fn update(&mut self, device_pixel_ratio: f32) {
-        if self.device_pixel_ratio == device_pixel_ratio {
-            return;
-        }
-        self.device_pixel_ratio = device_pixel_ratio;
-        self.font.average_width = self.average_width();
-        self.font.ascent = self.ascent();
-        self.font.descent = self.descent();
-        self.font.space_width = self.space_width();
-        self.font.max_width = self.max_width();
-        self.font.underline_thickness = self.underline_thickness();
-        self.font.underline_position = self.underline_position();
-        self.font.height = self.height();
-        self.font.baseline_offset = self.baseline_offset();
-    }
 }
 
-pub type WRFontRef<'a> = ExternalPtr<WRFont>;
+pub type WRFontRef = ExternalPtr<WRFont>;
 
 extern "C" fn open_font(frame: *mut frame, font_entity: LispObject, pixel_size: i32) -> LispObject {
     log::trace!("open font: {:?}", pixel_size);
@@ -507,30 +414,36 @@ extern "C" fn open_font(frame: *mut frame, font_entity: LispObject, pixel_size: 
         return Qnil;
     }
 
-    wr_font.font.pixel_size = pixel_size as i32;
-
     let font_result = font_result.unwrap();
     wr_font.face_id = font_result.info.id;
 
-    // store face info
     let face = &font_result.face;
-    wr_font.units_per_em = face.units_per_em();
-    wr_font.underline_metrics = face.underline_metrics().unwrap();
-    wr_font.ascent = face.ascender();
-    wr_font.descent = face.descender();
-    wr_font.average_width = face.glyph_hor_advance(ttf_parser::GlyphId(0)).unwrap();
-    wr_font.frame_id = frame.unique_id();
-    wr_font.update(frame.scale_factor() as f32);
+    let units_per_em = face.units_per_em();
+    let underline_metrics = face.underline_metrics().unwrap();
+    let ascent = face.ascender();
+    let descent = face.descender();
+    let average_width = face.glyph_hor_advance(ttf_parser::GlyphId(0)).unwrap();
+
+    let scale = pixel_size as f32 / units_per_em as f32;
+    wr_font.scale = scale;
+
+    wr_font.font.pixel_size = pixel_size as i32;
+    wr_font.font.average_width = (average_width as f32 * scale) as i32;
+    wr_font.font.ascent = (scale * ascent as f32).round() as i32;
+    wr_font.font.descent = (-scale * descent as f32).round() as i32;
+    wr_font.font.space_width = wr_font.font.average_width;
+    wr_font.font.max_width = wr_font.font.average_width;
+    wr_font.font.underline_thickness = (scale * underline_metrics.thickness as f32) as i32;
+    wr_font.font.underline_position = (scale * underline_metrics.position as f32) as i32;
+
+    wr_font.font.height = (scale * (ascent - descent) as f32).round() as i32;
+    wr_font.font.baseline_offset = 0;
 
     let driver = FontDriver::global();
     wr_font.font.driver = &driver.0;
 
-    let font = font_object.as_lisp_object();
-
-    wrfonts().lock().unwrap().push(font.clone());
-
     log::trace!("open font done: {:?}", pixel_size);
-    font
+    font_object.as_lisp_object()
 }
 
 extern "C" fn close_font(_font: *mut font) {}
@@ -602,8 +515,8 @@ extern "C" fn text_extents(
         (*metrics).lbearing = 0;
         (*metrics).rbearing = width as i16;
         (*metrics).width = width as i16;
-        (*metrics).ascent = font.ascent() as i16;
-        (*metrics).descent = font.descent() as i16;
+        (*metrics).ascent = font.font.ascent as i16;
+        (*metrics).descent = font.font.descent as i16;
     }
 }
 

--- a/rust_src/crates/webrender/src/gl/context_impl/glutin.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/glutin.rs
@@ -37,7 +37,7 @@ impl GLContextTrait for ContextImpl {
         let window_handle = frame
             .window_handle()
             .expect("Failed to get raw window handle from frame");
-        let size = frame.size();
+        let size = frame.physical_size();
 
         let width = NonZeroU32::new(size.width as u32).unwrap();
         let height = NonZeroU32::new(size.height as u32).unwrap();

--- a/rust_src/crates/webrender/src/gl/context_impl/gtk3.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/gtk3.rs
@@ -84,6 +84,7 @@ impl GLContextTrait for ContextImpl {
 
             fixed.put(&area, 0, 0);
             area.grab_focus();
+            frame.dynamic_resize();
             (fixed, area)
         };
 

--- a/rust_src/crates/webrender/src/gl/context_impl/gtk3.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/gtk3.rs
@@ -109,13 +109,17 @@ impl GLContextTrait for ContextImpl {
     fn resize(&self, _size: &DeviceIntSize) {
         #[cfg(window_system_pgtk)]
         {
-            if self.fixed.allocated_width() != self.area.allocated_width()
-                && self.fixed.allocated_height() != self.area.allocated_height()
-            {
-                self.area.set_width_request(self.fixed.allocated_width());
-                self.area.set_height_request(self.fixed.allocated_height());
-                self.fixed.move_(&self.area, 0, 0);
-            }
+            let p_alloc = self.fixed.allocation();
+            let me_alloc = self.area.allocation();
+            let allocation = gtk::Allocation::new(
+                me_alloc.x(),
+                me_alloc.y(),
+                p_alloc.width(),
+                p_alloc.height(),
+            );
+            log::debug!("gl_area allocation {allocation:?} to match fixed parent {p_alloc:?}.");
+            self.area.size_allocate(&allocation);
+            self.fixed.move_(&self.area, 0, 0);
         }
     }
 

--- a/rust_src/crates/webrender/src/gl/context_impl/surfman.rs
+++ b/rust_src/crates/webrender/src/gl/context_impl/surfman.rs
@@ -39,7 +39,7 @@ impl GLContextTrait for ContextImpl {
         let window_handle = frame
             .window_handle()
             .expect("Failed to get raw window handle from frame");
-        let size = frame.size();
+        let size = frame.physical_size();
 
         let connection = match Connection::from_raw_display_handle(display_handle) {
             Ok(connection) => connection,

--- a/rust_src/crates/webrender/src/input.rs
+++ b/rust_src/crates/webrender/src/input.rs
@@ -1,3 +1,4 @@
+use crate::window_system::api::dpi::LogicalPosition;
 use crate::window_system::frame::LispFrameWinitExt;
 use crate::window_system::{keycode_to_emacs_key_name, to_emacs_modifiers, virtual_keycode};
 
@@ -200,7 +201,7 @@ impl InputProcessor {
             _ => todo!(),
         };
 
-        let mut pos = PhysicalPosition::new(0, 0);
+        let mut pos = LogicalPosition::new(0, 0);
 
         if let Some(frame) = top_frame.as_frame() {
             pos = frame.cursor_position();
@@ -289,7 +290,7 @@ impl InputProcessor {
 
         let (kind, is_upper, lines) = event_meta.unwrap();
 
-        let mut pos = PhysicalPosition::new(0, 0);
+        let mut pos = LogicalPosition::new(0, 0);
 
         if let Some(frame) = top_frame.as_frame() {
             pos = frame.cursor_position();

--- a/rust_src/crates/webrender/src/output.rs
+++ b/rust_src/crates/webrender/src/output.rs
@@ -2,6 +2,8 @@ use super::display_info::DisplayInfoRef;
 use super::font::FontRef;
 use crate::font_db::FontDB;
 use crate::gl::context::GLContextTrait;
+#[cfg(window_system_pgtk)]
+use crate::window_system::frame::LispFramePgtkExt;
 use crate::window_system::output::output;
 use crate::window_system::output::OutputInner;
 use crate::window_system::output::OutputInnerRef;
@@ -88,8 +90,12 @@ impl Canvas {
         txn.set_root_pipeline(pipeline_id);
         let mut api = sender.create_api();
         let device_size = frame.size();
+        gl_context.resize(&device_size);
         let document_id = api.add_document(device_size);
         api.send_transaction(document_id, txn);
+
+        #[cfg(window_system_pgtk)]
+        frame.dynamic_resize();
 
         Self {
             fonts: HashMap::new(),

--- a/rust_src/crates/webrender/src/util.rs
+++ b/rust_src/crates/webrender/src/util.rs
@@ -1,23 +1,24 @@
+use euclid::Scale;
 use webrender::api::units::*;
 
 pub trait HandyDandyRectBuilder {
-    fn to(&self, x2: i32, y2: i32) -> LayoutRect;
-    fn by(&self, w: i32, h: i32) -> LayoutRect;
+    fn to(&self, x2: i32, y2: i32, scale: f32) -> LayoutRect;
+    fn by(&self, w: i32, h: i32, scale: f32) -> LayoutRect;
 }
 // Allows doing `(x, y).to(x2, y2)` or `(x, y).by(width, height)` with i32
 // values to build a f32 LayoutRect
 impl HandyDandyRectBuilder for (i32, i32) {
-    fn to(&self, x2: i32, y2: i32) -> LayoutRect {
+    fn to(&self, x2: i32, y2: i32, scale: f32) -> LayoutRect {
         LayoutRect::from_origin_and_size(
             LayoutPoint::new(self.0 as f32, self.1 as f32),
             LayoutSize::new((x2 - self.0) as f32, (y2 - self.1) as f32),
-        )
+        ) * Scale::new(scale)
     }
 
-    fn by(&self, w: i32, h: i32) -> LayoutRect {
+    fn by(&self, w: i32, h: i32, scale: f32) -> LayoutRect {
         LayoutRect::from_origin_and_size(
             LayoutPoint::new(self.0 as f32, self.1 as f32),
             LayoutSize::new(w as f32, h as f32),
-        )
+        ) * Scale::new(scale)
     }
 }

--- a/rust_src/crates/webrender/src/window_system/pgtk/output.rs
+++ b/rust_src/crates/webrender/src/window_system/pgtk/output.rs
@@ -6,12 +6,14 @@ use crate::output::CanvasRef;
 use std::ptr;
 
 pub struct OutputInner {
+    pub scale_factor: f64,
     pub canvas: CanvasRef,
 }
 
 impl Default for OutputInner {
     fn default() -> Self {
         OutputInner {
+            scale_factor: 0.0,
             canvas: CanvasRef::new(ptr::null_mut() as *mut _ as *mut Canvas),
         }
     }

--- a/rust_src/crates/webrender/src/window_system/winit/term.rs
+++ b/rust_src/crates/webrender/src/window_system/winit/term.rs
@@ -373,10 +373,14 @@ extern "C" fn winit_read_input_event(terminal: *mut terminal, hold_quit: *mut in
                     }
 
                     WindowEvent::Resized(size) => {
-                        let size = DeviceIntSize::new(size.width as i32, size.height as i32);
-
                         let mut frame: LispFrameRef = frame.into();
-                        frame.handle_size_change(size, frame.winit_scale_factor());
+                        let scale_factor = frame.winit_scale_factor();
+                        let size = DeviceIntSize::new(
+                            (size.width as f64 / scale_factor).round() as i32,
+                            (size.height as f64 / scale_factor).round() as i32,
+                        );
+
+                        frame.handle_size_change(size, scale_factor);
                     }
 
                     WindowEvent::ScaleFactorChanged {

--- a/src/frame.c
+++ b/src/frame.c
@@ -906,10 +906,6 @@ adjust_frame_size (struct frame *f, int new_text_width, int new_text_height,
 /**   f->resized_p = (new_native_width != old_native_width **/
 /** 		  || new_native_height != old_native_height); **/
 
-#if defined (USE_WEBRENDER) && defined (HAVE_PGTK)
-  wr_adjust_canvas_size (f, new_native_width, new_native_height);
-#endif
-
   unblock_input ();
 
 #ifdef HAVE_WINDOW_SYSTEM

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -4906,6 +4906,16 @@ pgtk_window_is_of_frame (struct frame *f, GdkWindow *window)
   return data.result;
 }
 
+#ifdef USE_WEBRENDER
+struct frame *
+pgtk_fixed_to_frame (GtkWidget *fixed)
+{
+  struct frame *f;
+  f = pgtk_any_window_to_frame (gtk_widget_get_window (fixed));
+  return f;
+}
+#endif
+
 /* Like x_window_to_frame but also compares the window with the widget's
    windows.  */
 static struct frame *
@@ -4973,23 +4983,6 @@ pgtk_handle_event (GtkWidget *widget, GdkEvent *event, gpointer *data)
     }
   return FALSE;
 }
-
-#ifdef USE_WEBRENDER
-static gboolean
-pgtk_handle_scale_changed (GtkWidget *widget, GdkEvent *event, gpointer *data)
-{
-  struct frame *f;
-  GtkWidget *frame_widget;
-  double scale_factor;
-
-  f = pgtk_any_window_to_frame (gtk_widget_get_window (widget));
-  scale_factor = pgtk_frame_scale_factor(f);
-
-  wr_handle_scale_factor_change (f, scale_factor);
-
-  return TRUE;
-}
-#endif
 
 #ifndef USE_WEBRENDER
 static void
@@ -6623,10 +6616,6 @@ pgtk_set_event_handler (struct frame *f)
 		    G_CALLBACK (pgtk_selection_event), NULL);
   g_signal_connect (G_OBJECT (FRAME_GTK_WIDGET (f)), "event",
 		    G_CALLBACK (pgtk_handle_event), NULL);
-#ifdef USE_WEBRENDER
-  g_signal_connect (G_OBJECT (FRAME_GTK_WIDGET (f)), "notify::scale-factor",
-		    G_CALLBACK (pgtk_handle_scale_changed), NULL);
-#endif
 }
 
 static void

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -5088,12 +5088,7 @@ size_allocate (GtkWidget *widget, GtkAllocation *alloc,
 
   if (f)
     {
-#if defined USE_WEBRENDER
-      double scale = FRAME_SCALE_FACTOR (f);
-      xg_frame_resized (f, alloc->width * scale, alloc->height * scale);
-#else
       xg_frame_resized (f, alloc->width, alloc->height);
-#endif
       pgtk_cr_update_surface_desired_size (f, alloc->width, alloc->height, false);
     }
 }
@@ -5899,13 +5894,7 @@ note_mouse_movement (struct frame *frame,
     {
       frame->mouse_moved = true;
       dpyinfo->last_mouse_scroll_bar = NULL;
-#ifndef USE_WEBRENDER
       note_mouse_highlight (frame, event->x, event->y);
-#else
-      note_mouse_highlight (frame,
-			    event->x * FRAME_SCALE_FACTOR (frame),
-			    event->y * FRAME_SCALE_FACTOR (frame));
-#endif
       /* Remember which glyph we're now on.  */
       remember_mouse_glyph (frame, event->x, event->y, r);
       dpyinfo->last_mouse_glyph_frame = frame;
@@ -6043,13 +6032,8 @@ construct_mouse_click (struct input_event *result,
 		       | (event->type == GDK_BUTTON_RELEASE
 			  ? up_modifier : down_modifier));
 
-#ifndef USE_WEBRENDER
   XSETINT (result->x, event->x);
   XSETINT (result->y, event->y);
-#else
-  XSETINT (result->x, event->x * FRAME_SCALE_FACTOR (f));
-  XSETINT (result->y, event->y * FRAME_SCALE_FACTOR (f));
-#endif
   XSETFRAME (result->frame_or_window, f);
   result->arg = Qnil;
   result->device = pgtk_get_device_for_event (FRAME_DISPLAY_INFO (f),

--- a/src/pgtkterm.h
+++ b/src/pgtkterm.h
@@ -666,6 +666,7 @@ extern double pgtk_frame_scale_factor (struct frame *);
 extern int pgtk_emacs_to_gtk_modifiers (struct pgtk_display_info *, int);
 
 #ifdef USE_WEBRENDER
+extern struct frame *pgtk_fixed_to_frame (GtkWidget *);
 #include "webrender_ffi.h"
 #endif  /* USE_WEBRENDER */
 

--- a/src/webrender_ffi.h
+++ b/src/webrender_ffi.h
@@ -44,10 +44,6 @@ extern Lisp_Object wr_new_font (struct frame *f, Lisp_Object font_object, int fo
 extern int
 wr_parse_color (struct frame *f, const char *color_name,
 		Emacs_Color * color);
-void
-wr_adjust_canvas_size (struct frame *f, int new_width, int new_height);
-void
-wr_handle_scale_factor_change (struct frame *f, double scale_factor);
 
 extern void syms_of_webrender(void);
 


### PR DESCRIPTION
This PR makes the frame/wrfont size (pixel_width/pixel_height) at scale 1 while the winit window and WR OpenGL surface size at real scale. We scale the produced glyphs from Emacs redisplay all together just before sending them to WebRender.

- Reverted previous font changes for scaling 
- Also fixed WR/PGTK child frame.

## [Issues to resolve before merge](https://github.com/emacs-ng/emacs-ng/pull/518#issuecomment-1465039846)
- [X] misplaced images:

[2023-03-11-22:29:45-screenshot](https://user-images.githubusercontent.com/22841038/224514293-521d09e1-e115-41b1-8eaf-0054f81d0c84.png)

- [x] misplaced graphical artefacts:
[2023-03-11-22:29:59-screenshot](https://user-images.githubusercontent.com/22841038/224514298-69bbb96b-9a58-4fc5-b605-2c68333362be.png)

(these lines appear as I navigate the helm buffer and clearly should be rendered in it)
- [x] recursive scaling loop:

[2023-03-11-22:31:51-screenshot](https://user-images.githubusercontent.com/22841038/224514347-b53b528e-e27b-41ad-aa51-51805201e896.png)

(caused by moving point up, clearly re scaling already scaled lines).

- [X] Does the image positioning code need to use the physical, not logical, position?
- [x] How do we fix the recursive scaling?
