### PR TITLE
Wr disable noto color emoji

### DIFF
--- a/rust_src/crates/webrender/src/font.rs
+++ b/rust_src/crates/webrender/src/font.rs
@@ -21,7 +21,6 @@ use emacs::{
         Qoblique, Qsemi_bold, Qthin, Qttf_parser, Qultra_bold,
     },
     lisp::{ExternalPtr, LispObject},
-    multibyte::LispStringRef,
     symbol::LispSymbolRef,
 };
 
@@ -90,8 +89,7 @@ impl LispFontLike {
         if tem.is_nil() {
             None
         } else {
-            let symbol_or_string = tem.as_symbol_or_string();
-            let string: LispStringRef = symbol_or_string.into();
+            let string: String = tem.into();
             let family_name = string.to_string().replace("-", "\\-");
 
             #[cfg(free_unix)]
@@ -121,9 +119,8 @@ impl LispFontLike {
         if slant.is_nil() {
             None
         } else {
-            let symbol_or_string = slant.as_symbol_or_string();
-            let string: LispStringRef = symbol_or_string.into();
-            match string.to_string().as_ref() {
+            let string: String = slant.into();
+            match string.as_ref() {
                 "Qnormal" => Some(Style::Normal),
                 "Qitalic" => Some(Style::Italic),
                 "Qoblique" => Some(Style::Oblique),

--- a/rust_src/crates/webrender/src/font.rs
+++ b/rust_src/crates/webrender/src/font.rs
@@ -18,7 +18,7 @@ use emacs::{
     frame::LispFrameRef,
     globals::{
         Qbold, Qextra_bold, Qextra_light, Qiso10646_1, Qitalic, Qlight, Qmedium, Qnil, Qnormal,
-        Qoblique, Qsemi_bold, Qthin, Qttf_parser, Qultra_bold,
+        Qoblique, Qsemi_bold, Qthin, Qttfp, Qultra_bold,
     },
     lisp::{ExternalPtr, LispObject},
     symbol::LispSymbolRef,
@@ -54,7 +54,7 @@ impl FontDriver {
             log::trace!("FONT_DRIVER is being created...");
             let mut font_driver = font_driver::default();
 
-            font_driver.type_ = Qttf_parser;
+            font_driver.type_ = Qttfp;
             font_driver.case_sensitive = true;
             font_driver.get_cache = Some(get_cache);
             font_driver.list = Some(list);
@@ -220,7 +220,7 @@ extern "C" fn match_(_f: *mut frame, spec: LispObject) -> LispObject {
         let entity: LispFontLike = unsafe { font_make_entity() }.into();
 
         // set type
-        entity.aset(font_property_index::FONT_TYPE_INDEX, Qttf_parser);
+        entity.aset(font_property_index::FONT_TYPE_INDEX, Qttfp);
 
         let family_name = f.families.get(0);
         if family_name.is_none() {
@@ -389,7 +389,7 @@ extern "C" fn open_font(frame: *mut frame, font_entity: LispObject, pixel_size: 
     .into();
 
     // set type
-    font_object.aset(font_property_index::FONT_TYPE_INDEX, Qttf_parser);
+    font_object.aset(font_property_index::FONT_TYPE_INDEX, Qttfp);
 
     // set name
     font_object.aset(
@@ -519,7 +519,7 @@ extern "C" fn text_extents(
 
 #[allow(unused_variables)]
 #[no_mangle]
-pub extern "C" fn register_ttf_parser_font_driver(f: *mut frame) {
+pub extern "C" fn register_ttfp_font_driver(f: *mut frame) {
     let driver = FontDriver::global();
     unsafe {
         register_font_driver(&driver.0, f);
@@ -528,16 +528,13 @@ pub extern "C" fn register_ttf_parser_font_driver(f: *mut frame) {
 
 #[allow(unused_variables)]
 #[no_mangle]
-pub extern "C" fn syms_of_ttf_parser_font() {
-    let ttf_parser_symbol =
-        CString::new("ttf-parser").expect("Failed to create string for intern function call");
-    def_lisp_sym!(Qttf_parser, "ttf-parser");
+pub extern "C" fn syms_of_ttfp_font() {
+    let ttfp_symbol =
+        CString::new("ttfp").expect("Failed to create string for intern function call");
+    def_lisp_sym!(Qttfp, "ttfp");
     unsafe {
-        Fprovide(
-            emacs::bindings::intern_c_string(ttf_parser_symbol.as_ptr()),
-            Qnil,
-        );
+        Fprovide(emacs::bindings::intern_c_string(ttfp_symbol.as_ptr()), Qnil);
     }
 
-    register_ttf_parser_font_driver(ptr::null_mut());
+    register_ttfp_font_driver(ptr::null_mut());
 }

--- a/rust_src/crates/webrender/src/window_system/winit/frame.rs
+++ b/rust_src/crates/webrender/src/window_system/winit/frame.rs
@@ -131,9 +131,7 @@ impl LispFrameWinitExt for LispFrameRef {
         let primary_monitor = event_loop.get_primary_monitor();
         let scale_factor = primary_monitor.scale_factor();
 
-        let invocation_name: emacs::multibyte::LispStringRef =
-            unsafe { emacs::bindings::globals.Vinvocation_name.into() };
-        let invocation_name = invocation_name.to_utf8();
+        let invocation_name: String = unsafe { emacs::bindings::globals.Vinvocation_name.into() };
 
         #[cfg(all(wayland_platform, use_winit))]
         let window_builder = {

--- a/rust_src/crates/webrender/src/wrterm.rs
+++ b/rust_src/crates/webrender/src/wrterm.rs
@@ -10,7 +10,6 @@ use crate::winit_term_init;
 use emacs::bindings::gui_update_cursor;
 use emacs::bindings::Fredraw_frame;
 use emacs::frame::Lisp_Frame;
-use emacs::multibyte::LispStringRef;
 use std::ffi::CString;
 use std::ptr;
 use webrender::api::*;
@@ -101,9 +100,9 @@ pub extern "C" fn winit_set_cursor_color(
     _old_val: LispObject,
 ) {
     let frame: LispFrameRef = f.into();
+    let color_str: String = arg.into();
 
-    let color_str: LispStringRef = arg.as_symbol_or_string().into();
-    let color_str = format!("{}", color_str.to_string());
+    let color_str = format!("{}", color_str);
     let color = lookup_color_by_name_or_hex(&color_str);
 
     if let Some(color) = color {

--- a/rust_src/crates/webrender/src/wrterm.rs
+++ b/rust_src/crates/webrender/src/wrterm.rs
@@ -2,7 +2,7 @@
 
 use crate::color::color_to_pixel;
 use crate::event_loop::WrEventLoop;
-use crate::font::register_ttf_parser_font_driver;
+use crate::font::register_ttfp_font_driver;
 use crate::window_system::{
     clipboard::ClipboardExt, frame::LispFrameWinitExt, keysym_to_emacs_key_name,
 };
@@ -293,7 +293,7 @@ pub fn winit_create_frame(parms: LispObject) -> LispFrameRef {
     #[cfg(use_tao)]
     crate::event_loop::ensure_window(frame.unique_id());
 
-    register_ttf_parser_font_driver(frame.as_mut());
+    register_ttfp_font_driver(frame.as_mut());
 
     frame.gui_default_parameter(
         parms,

--- a/src/font.c
+++ b/src/font.c
@@ -5755,7 +5755,7 @@ match.  */);
 
 #ifdef HAVE_WINDOW_SYSTEM
 #ifdef USE_WEBRENDER
-  syms_of_ttf_parser_font();
+  syms_of_ttfp_font();
 #else
 #ifdef HAVE_FREETYPE
   syms_of_ftfont ();

--- a/src/font.h
+++ b/src/font.h
@@ -974,8 +974,8 @@ extern struct font_driver ftcrhbfont_driver;
 extern void syms_of_ftcrfont (void);
 #endif
 #ifdef USE_WEBRENDER
-extern void register_ttf_parser_font_driver(struct frame *);
-extern void syms_of_ttf_parser_font(void);
+extern void register_ttfp_font_driver(struct frame *);
+extern void syms_of_ttfp_font(void);
 #endif
 
 #ifndef FONT_DEBUG

--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -1396,7 +1396,7 @@ This function is an internal primitive--use `make-frame' instead.  */ )
   register_font_driver (&ftcrhbfont_driver, f);
 #endif	/* HAVE_HARFBUZZ */
 #else
-register_ttf_parser_font_driver(f);
+register_ttfp_font_driver(f);
 #endif  /* USE_WEBRENDER */
 
   image_cache_refcount =
@@ -2756,7 +2756,7 @@ x_create_tip_frame (struct pgtk_display_info *dpyinfo, Lisp_Object parms, struct
   register_font_driver (&ftcrhbfont_driver, f);
 #endif	/* HAVE_HARFBUZZ */
 #else
-register_ttf_parser_font_driver(f);
+register_ttfp_font_driver(f);
 #endif  /* USE_WEBRENDER */
 
   image_cache_refcount =

--- a/src/xfaces.c
+++ b/src/xfaces.c
@@ -7337,8 +7337,10 @@ other font of the appropriate family and registry is available.  */);
 	       doc: /* List of ignored fonts.
 Each element is a regular expression that matches names of fonts to
 ignore.  */);
-#ifdef HAVE_XFT
+#if defined(HAVE_XFT) || defined(USE_WEBRENDER)
   /* This font causes libXft crashes, so ignore it by default.  Bug#37786.  */
+  /* WebRender currently has issue rendering Color Font.
+     See: https://bugzilla.mozilla.org/show_bug.cgi?id=1565588 */
   Vface_ignored_fonts = list1 (build_string ("Noto Color Emoji"));
 #else
   Vface_ignored_fonts = Qnil;


### PR DESCRIPTION
WebRender's [wr_glyph_rasterizer](https://github.com/servo/webrender/tree/master/wr_glyph_rasterizer) currently is unable to handle color fonts like "Noto Color Emoji". See [#498](https://github.com/emacs-ng/emacs-ng/issues/498). We disable "Noto Color Emoji" for WR renderer in this PR.

Also included some code refactor:

- Added debug trait for `LispObject`.
So we can debug `LispObject` obj with `println!({obj:?})`
- Added `From/To<String>` trait for `LispObject`.
- Implemented overstrike face for WR renderer.
- rename `ttf_parser` to `tffp` according to their [c-api](https://github.com/RazrFalcon/ttf-parser/blob/master/c-api/ttfparser.h)