### PR TITLE
Ignore .direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,4 +398,4 @@ exec/configure
 exec/*.s.s
 
 # Ignore .direnv
-.direnv
+.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ exec/config.h.in
 exec/config-mips.m4
 exec/configure
 exec/*.s.s
+
+# Ignore .direnv
+.direnv


### PR DESCRIPTION
Hi all,

NixOS users often use direnv to load and unload the Nix dev shell.
Direnv creates a cache of your shell, which is very handy, but it should not be pushed to the repository.

This PR adds the ```.direnv``` directory to the ```.gitignore```.
