### PR TITLE
Use winit event_loop raw fd on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin_sleep"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a978649eaf70006b082e79c832bd72556ac1393eaf564d686e919dca2347f"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5240,6 +5249,7 @@ dependencies = [
  "ng-bindgen",
  "once_cell",
  "raw-window-handle",
+ "spin_sleep",
  "webrender_api",
  "winit",
 ]

--- a/configure.ac
+++ b/configure.ac
@@ -7553,6 +7553,7 @@ CARGO_FLAGS="$CARGO_FLAGS"
 else
 CARGO_FLAGS="$CARGO_FLAGS --release"
 fi
+CARGO_FLAGS="$CARGO_FLAGS -Zgitoxide=fetch -Zgit=shallow-deps,shallow-index"
 AC_SUBST(CARGO_FLAGS)
 
 case "${opsys}" in

--- a/configure.ac
+++ b/configure.ac
@@ -3305,7 +3305,7 @@ dnl use the toolkit if we have gtk, or X11R5 or newer.
     term_header=w32term.h
   ;;
   winit )
-    term_header=wrterm.h
+    term_header=winitterm.h
   ;;
   pgtk )
     term_header=pgtkterm.h

--- a/rust_src/crates/winit-term/Cargo.toml
+++ b/rust_src/crates/winit-term/Cargo.toml
@@ -22,6 +22,7 @@ bit-vec = "0.6.3"
 once_cell = "1.16.0"
 raw-window-handle.workspace = true
 winit.workspace = true
+spin_sleep = "1.2"
 
 [build-dependencies]
 ng-bindgen = { path = "../../ng-bindgen" }

--- a/rust_src/crates/winit-term/build.rs
+++ b/rust_src/crates/winit-term/build.rs
@@ -33,9 +33,5 @@ fn main() {
         windows_platform: { target_os = "windows" },
         apple: { any(target_os = "ios", target_os = "macos") },
         free_unix: { all(unix, not(apple), not(android_platform)) },
-
-        // X11/wayland are winit specific
-        x11_platform: { all(feature = "x11", free_unix, not(wasm), use_winit)},
-        wayland_platform: { all(feature = "wayland", free_unix, not(wasm), use_winit) },
     }
 }

--- a/rust_src/crates/winit-term/src/fns.rs
+++ b/rust_src/crates/winit-term/src/fns.rs
@@ -32,8 +32,34 @@ use emacs::{
     definitions::EmacsInt,
     frame::{all_frames, window_frame_live_or_selected, FrameRef},
     globals::{
-        Qbackground_color, Qfont, Qfont_backend, Qforeground_color, Qleft_fringe, Qminibuffer,
-        Qname, Qnil, Qparent_id, Qright_fringe, Qt, Qterminal, Qunbound, Qwinit, Qx_create_frame_1,
+        QAndroidNdk,
+        QAppKit,
+        QDrm,
+        QGbm,
+        QHaiku,
+        QOrbital,
+        QUiKit,
+        QWayland,
+        QWeb, //QWebCanvas, QWebOffscreenCanvas,
+        QWin32,
+        QWinRt,
+        QXcb,
+        QXlib,
+        Qbackground_color,
+        Qfont,
+        Qfont_backend,
+        Qforeground_color,
+        Qleft_fringe,
+        Qminibuffer,
+        Qname,
+        Qnil,
+        Qparent_id,
+        Qright_fringe,
+        Qt,
+        Qterminal,
+        Qunbound,
+        Qwinit,
+        Qx_create_frame_1,
         Qx_create_frame_2,
     },
     lisp::{ExternalPtr, LispObject},
@@ -809,12 +835,72 @@ pub fn winit_frame_edges(frame: LispObject, type_: LispObject) -> LispObject {
     frame.edges(type_)
 }
 
+/// Return the name of the RawWindowHandle of FRAME.
+/// The optional argument FRAME specifies which frame to ask about.
+/// FRAME should be a frame object.
+/// If omitted or nil, that stands for the selected frame.
+#[lisp_fn(min = "0")]
+pub fn winit_raw_window_handle_name(frame: LispObject) -> LispObject {
+    use raw_window_handle::HasRawWindowHandle;
+    use raw_window_handle::RawWindowHandle;
+    let frame: FrameRef = window_frame_live_or_selected(frame);
+    match frame.raw_window_handle() {
+        RawWindowHandle::UiKit(_) => QUiKit,
+        RawWindowHandle::AppKit(_) => QAppKit,
+        RawWindowHandle::Orbital(_) => QOrbital,
+        RawWindowHandle::Xlib(_) => QXlib,
+        RawWindowHandle::Xcb(_) => QXcb,
+        RawWindowHandle::Wayland(_) => QWayland,
+        RawWindowHandle::Drm(_) => QDrm,
+        RawWindowHandle::Gbm(_) => QGbm,
+        RawWindowHandle::Win32(_) => QWin32,
+        RawWindowHandle::WinRt(_) => QWinRt,
+        RawWindowHandle::Web(_) => QWeb,
+        // RawWindowHandle::WebCanvas(_) => QWebCanvas,
+        // RawWindowHandle::WebOffscreenCanvas(_) => QWebOffscreenCanvas,
+        RawWindowHandle::AndroidNdk(_) => QAndroidNdk,
+        RawWindowHandle::Haiku(_) => QHaiku,
+        _ => Qnil,
+    }
+}
+
 #[no_mangle]
 #[allow(unused_doc_comments)]
 pub extern "C" fn syms_of_winit_term() {
     def_lisp_sym!(Qwinit, "winit");
+    def_lisp_sym!(QUiKit, "UiKit");
+    def_lisp_sym!(QAppKit, "AppKit");
+    def_lisp_sym!(QOrbital, "Orbital");
+    def_lisp_sym!(QXlib, "Xlib");
+    def_lisp_sym!(QXcb, "Xcb");
+    def_lisp_sym!(QWayland, "Wayland");
+    def_lisp_sym!(QDrm, "Drm");
+    def_lisp_sym!(QGbm, "Gbm");
+    def_lisp_sym!(QWin32, "Win32");
+    def_lisp_sym!(QWinRt, "WinRt");
+    def_lisp_sym!(QWeb, "Web");
+    // def_lisp_sym!(QWebCanvas, "WebCanvas");
+    // def_lisp_sym!(QWebOffscreenCanvas, "WebOffscreenCanvas");
+    def_lisp_sym!(QAndroidNdk, "AndroidNdk");
+    def_lisp_sym!(QHaiku, "Haiku");
+
     unsafe {
         Fprovide(Qwinit, Qnil);
+        Fprovide(QUiKit, Qnil);
+        Fprovide(QAppKit, Qnil);
+        Fprovide(QOrbital, Qnil);
+        Fprovide(QXlib, Qnil);
+        Fprovide(QXcb, Qnil);
+        Fprovide(QWayland, Qnil);
+        Fprovide(QDrm, Qnil);
+        Fprovide(QGbm, Qnil);
+        Fprovide(QWin32, Qnil);
+        Fprovide(QWinRt, Qnil);
+        Fprovide(QWeb, Qnil);
+        // Fprovide(QWebCanvas, Qnil);
+        // Fprovide(QWebOffscreenCanvas, Qnil);
+        Fprovide(QAndroidNdk, Qnil);
+        Fprovide(QHaiku, Qnil);
     }
 
     let winit_keysym_table = unsafe { make_hash_table(&hashtest_eql, 900, Weak_None, false) };

--- a/rust_src/crates/winit-term/src/frame.rs
+++ b/rust_src/crates/winit-term/src/frame.rs
@@ -82,7 +82,7 @@ impl FrameExtWinit for FrameRef {
 
         let invocation_name: String = unsafe { emacs::bindings::globals.Vinvocation_name.into() };
 
-        #[cfg(wayland_platform)]
+        #[cfg(free_unix)]
         let window_builder = {
             use winit::platform::wayland::WindowBuilderExtWayland;
             window_builder.with_name(&invocation_name, "")

--- a/rust_src/wrapper.h
+++ b/rust_src/wrapper.h
@@ -61,7 +61,7 @@
 #include "window.h"
 #include "xgselect.h"
 #ifdef HAVE_WINIT
-# include "wrterm.h"
+# include "winitterm.h"
 #endif
 #ifdef HAVE_PGTK
 # include "pgtkterm.h"

--- a/src/frame.h
+++ b/src/frame.h
@@ -655,7 +655,7 @@ struct frame
     struct pgtk_output *pgtk;		/* From pgtkterm.h. */
     struct haiku_output *haiku;		/* From haikuterm.h. */
     struct android_output *android;	/* From androidterm.h.  */
-    struct winit_output *winit;	        /* From wrterm.h. */
+    struct winit_output *winit;	        /* From winitterm.h. */
   }
   output_data;
 

--- a/src/termhooks.h
+++ b/src/termhooks.h
@@ -545,7 +545,7 @@ struct terminal
     struct pgtk_display_info *pgtk;		/* pgtkterm.h */
     struct haiku_display_info *haiku;		/* haikuterm.h */
     struct android_display_info *android;	/* androidterm.h */
-    struct winit_display_info *winit;	        /* wrterm.h */
+    struct winit_display_info *winit;	        /* winitterm.h */
   } display_info;
 
 

--- a/src/winitterm.h
+++ b/src/winitterm.h
@@ -1,5 +1,5 @@
-#ifndef __WRTERM_H_
-#define __WRTERM_H_
+#ifndef __WINITTERM_H_
+#define __WINITTERM_H_
 
 #include "dispextern.h"
 
@@ -44,9 +44,7 @@ struct winit_display_info
      mouse-face.  */
   Mouse_HLInfo mouse_highlight;
 
-  /* The number of fonts actually stored in wr_font_table.
-     font_table[n] is used and valid if 0 <= n < n_fonts. 0 <=
-     n_fonts <= font_table_size. and font_table[i].name != 0. */
+  /* The number of fonts opened for this display.  */
   int n_fonts;
 
   /* Pointer to bitmap records.  */
@@ -165,4 +163,4 @@ extern void syms_of_winit_term(void);
 
 #include "webrender_ffi.h"
 
-#endif // __WRTERM_H_
+#endif // __WINITTERM_H_


### PR DESCRIPTION
* Using winit event_loop raw fd on linux
Which fixed the key pressed not working
* Add lisp fn `winit_raw_window_handle_name`
Which is useful for inspecting which display(wayland/x11 etc) is in use currently
* Enable Cargo shallow clones 